### PR TITLE
OTEL Tracing for All Routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991697fafbb3c5c088e4ae4cefecf9a906c45f30c7f5153a2d8044e90f8e4d1f"
+dependencies = [
+ "axum",
+ "futures",
+ "http",
+ "opentelemetry 0.19.0",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions 0.11.0",
+ "opentelemetry-zipkin",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,12 +474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +511,7 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -878,6 +893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,12 +950,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,8 +975,8 @@ dependencies = [
  "async-trait",
  "clap",
  "indexmap",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.18.0",
+ "opentelemetry_sdk 0.18.0",
  "reqwest",
  "schemars",
  "serde",
@@ -977,12 +995,12 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-macros",
+ "axum-tracing-opentelemetry",
  "clap",
  "ndc-client",
- "opentelemetry",
+ "opentelemetry 0.19.0",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "opentelemetry-semantic-conventions 0.10.0",
  "prometheus",
  "serde",
  "serde_json",
@@ -1088,23 +1106,48 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_api 0.18.0",
+ "opentelemetry_sdk 0.18.0",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+dependencies = [
+ "opentelemetry_api 0.19.0",
+ "opentelemetry_sdk 0.19.0",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a819b71d6530c4297b49b3cae2939ab3a8cc1b9f382826a1bc29dd0ca3864906"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry_api 0.19.0",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
+checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
  "http",
- "opentelemetry",
+ "opentelemetry 0.19.0",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "prost",
+ "reqwest",
  "thiserror",
  "tokio",
  "tonic",
@@ -1112,16 +1155,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
+checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
 dependencies = [
  "futures",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.19.0",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -1130,7 +1172,36 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b02e0230abb0ab6636d18e2ba8fa02903ea63772281340ccac18e0af3ec9eeb"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.18.0",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e33428e6bf08c6f7fcea4ddb8e358fab0fe48ab877a87c70c6ebe20f673ce5"
+dependencies = [
+ "opentelemetry 0.19.0",
+]
+
+[[package]]
+name = "opentelemetry-zipkin"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fd48caee5e1db71454c95be32d1daeb6fae265321ff8f51b1efc8a50b0be80"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "once_cell",
+ "opentelemetry 0.19.0",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions 0.11.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "typed-builder",
 ]
 
 [[package]]
@@ -1139,7 +1210,6 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
 dependencies = [
- "fnv",
  "futures-channel",
  "futures-util",
  "indexmap",
@@ -1150,10 +1220,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry_api"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api 0.18.0",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1163,7 +1267,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "once_cell",
- "opentelemetry_api",
+ "opentelemetry_api 0.19.0",
  "percent-encoding",
  "rand",
  "thiserror",
@@ -1205,16 +1309,6 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
-
-[[package]]
-name = "petgraph"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
 
 [[package]]
 name = "pin-project"
@@ -1261,16 +1355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,28 +1389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,15 +1399,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -1410,8 +1463,17 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.3.2",
+ "regex-syntax 0.7.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1422,8 +1484,14 @@ checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1951,19 +2019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,17 +2125,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.19.0",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2088,6 +2174,17 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "typed-builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6179333b981641242a768f30f371c9baccbfcc03749627000c500ab88bf4528b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "unicase"
@@ -2129,6 +2226,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"
@@ -2252,17 +2355,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,6 @@ dependencies = [
  "opentelemetry 0.19.0",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions 0.11.0",
- "opentelemetry-zipkin",
  "tower",
  "tower-http",
  "tracing",
@@ -1185,26 +1184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-zipkin"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fd48caee5e1db71454c95be32d1daeb6fae265321ff8f51b1efc8a50b0be80"
-dependencies = [
- "async-trait",
- "futures-core",
- "http",
- "once_cell",
- "opentelemetry 0.19.0",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions 0.11.0",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "typed-builder",
-]
-
-[[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,17 +2153,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "typed-builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6179333b981641242a768f30f371c9baccbfcc03749627000c500ab88bf4528b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ path = "bin/main.rs"
 axum-tracing-opentelemetry = { version = "0.11.0", features = [
     "otlp",
     "tracing_subscriber_ext",
-    "zipkin",                 # provides b3 and b3multi propagators
 ] }
 opentelemetry = "0.19.0" # must be same version axum-tracing-opentelemetry uses
 opentelemetry-otlp = { version = "0.12.0", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ axum = "0.6.18"
 axum-macros = "0.3.7"
 clap = { version = "4.3.9", features = ["derive", "env"] }
 ndc-client = { git = "http://github.com/hasura/ndc-spec.git", rev = "f3a6759" }
-# opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-# opentelemetry_sdk = "0.18.0"
-# opentelemetry-otlp = "0.11.0"
 opentelemetry-semantic-conventions = "0.10.0"
 prometheus = "0.13.3"
 serde = "1.0.164"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,23 @@ name = "ndc_hub_example"
 path = "bin/main.rs"
 
 [dependencies]
+axum-tracing-opentelemetry = { version = "0.11.0", features = [
+    "otlp",
+    "tracing_subscriber_ext",
+    "zipkin",                 # provides b3 and b3multi propagators
+] }
+opentelemetry = "0.19.0" # must be same version axum-tracing-opentelemetry uses
+opentelemetry-otlp = { version = "0.12.0", features = [
+    "reqwest-client",
+] } # must be same version axum-tracing-opentelemetry uses
 async-trait = "0.1.68"
 axum = "0.6.18"
 axum-macros = "0.3.7"
 clap = { version = "4.3.9", features = ["derive", "env"] }
 ndc-client = { git = "http://github.com/hasura/ndc-spec.git", rev = "f3a6759" }
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-opentelemetry_sdk = "0.18.0"
-opentelemetry-otlp = "0.11.0"
+# opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
+# opentelemetry_sdk = "0.18.0"
+# opentelemetry-otlp = "0.11.0"
 opentelemetry-semantic-conventions = "0.10.0"
 prometheus = "0.13.3"
 serde = "1.0.164"

--- a/README.md
+++ b/README.md
@@ -51,3 +51,25 @@ curl http://localhost:8100/schema
 ```
 
 (the default port 8100 can be changed using `--port`)
+
+## Tracing
+
+The serve command emits OTLP trace information. This can be used to see details of requests across services.
+
+To enable tracing you must:
+
+* Use the NDC-Hub option `--otlp-endpoint` e.g. `http://localhost:4317`
+* Or, set the NDC-Hub ENV Variable `OTLP_ENDPOINT`
+* Or, set the `tracing` ENV Variable `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+
+For additional service information you can:
+
+* Set `OTEL_SERVICE_NAME` e.g. `ndc_hub_example`
+* Set `OTEL_RESOURCE_ATTRIBUTES` e.g. `key=value, k = v , a= x, a=z`
+
+
+To view trace information during local development you can run a Jager server via Docker:
+
+```
+docker run --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:1.45
+```

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use clap::Args;
 use ndc_client::models;
+use tracing::info_span;
 use std::{collections::BTreeMap, error::Error};
 use thiserror::Error;
 
@@ -292,6 +293,9 @@ impl Connector for Example {
     async fn get_schema(
         _configuration: &Self::Configuration,
     ) -> Result<models::SchemaResponse, SchemaError> {
+
+        info_span!("trying sub-span get_schema");
+
         Ok(models::SchemaResponse {
             collections: vec![],
             functions: vec![],

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -235,6 +235,11 @@ pub trait Connector {
     ) -> Result<models::QueryResponse, QueryError>;
 }
 
+async fn nonsense_function() -> () {
+    info_span!("Spanning from inside an async function: nonsense_function");
+    return ();
+}
+
 #[derive(Clone, Default)]
 pub struct Example {}
 
@@ -295,6 +300,12 @@ impl Connector for Example {
     ) -> Result<models::SchemaResponse, SchemaError> {
 
         info_span!("trying sub-span get_schema");
+
+        // Testing out spanning across async boundaries
+        let delegator_span = info_span!("trying sub-span delegation to async function inside get_schema");
+        delegator_span.in_scope(|| async {
+            nonsense_function().await;
+        }).await;
 
         Ok(models::SchemaResponse {
             collections: vec![],

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -88,8 +88,6 @@ where
 {
     let CliArgs { command } = CliArgs::<C>::parse();
 
-    axum_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers().expect("Couldn't init OT");
-
     match command {
         Command::Serve(serve_command) => serve::<C>(serve_command).await,
         Command::GenerateConfiguration(configure_command) => {
@@ -110,6 +108,8 @@ where
     serve_command.otlp_endpoint.map(|e| {
         env::set_var(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, e);
     });
+
+    axum_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers().expect("Couldn't init OT");
 
     let server_state = init_server_state::<C>(serve_command.configuration).await;
 

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -43,7 +43,7 @@ struct ServeCommand {
     #[arg(long, value_name = "CONFIGURATION_FILE", env = "CONFIGURATION_FILE")]
     configuration: String,
     #[arg(long, value_name = "OTLP_ENDPOINT", env = "OTLP_ENDPOINT")]
-    otlp_endpoint: Option<String>,
+    otlp_endpoint: Option<String>, // TODO: Figure out if we want to use this, or use OTEL_EXPORTER_OTLP_TRACES_ENDPOINT instead
     #[arg(long, value_name = "PORT", env = "PORT")]
     port: Option<String>,
 }

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -3,21 +3,22 @@ use axum::{
     extract::State,
     http::StatusCode,
     routing::{get, post},
-    Json, Router,
+    Json, Router
 };
 use clap::{Args, Parser, Subcommand};
 use ndc_client::models::{
     CapabilitiesResponse, ExplainResponse, MutationRequest, MutationResponse, QueryRequest,
     QueryResponse, SchemaResponse,
 };
-use opentelemetry::{global, KeyValue};
-use opentelemetry_otlp::{WithExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT};
-use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_otlp::{OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT};
+// use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::Tracer};
 use prometheus::Registry;
 use serde::{de::DeserializeOwned, Serialize};
 use std::error::Error;
-use std::{env, net::SocketAddr};
+use std::net::SocketAddr;
 use tower_http::trace::TraceLayer;
+// use opentelemetry::trace::Tracer as Tracer2;
+use axum_tracing_opentelemetry::{opentelemetry_tracing_layer, response_with_trace_layer};
 
 #[derive(Parser)]
 struct CliArgs<C: Connector>
@@ -54,6 +55,7 @@ pub struct ServerState<C: Connector> {
     configuration: C::Configuration,
     state: C::State,
     metrics: Registry,
+    // tracer: Arc<sdk::trace::Tracer>,
 }
 
 /// A default main function for a connector.
@@ -88,6 +90,8 @@ where
 {
     let CliArgs { command } = CliArgs::<C>::parse();
 
+    axum_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers().expect("Couldn't init OT");
+
     match command {
         Command::Serve(serve_command) => serve::<C>(serve_command).await,
         Command::GenerateConfiguration(configure_command) => {
@@ -104,37 +108,13 @@ where
     C::Configuration: Serialize + DeserializeOwned + Sync + Send + Clone,
     C::State: Sync + Send + Clone,
 {
-    global::set_text_map_propagator(TraceContextPropagator::new());
+    // global::set_text_map_propagator(TraceContextPropagator::new());
 
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .init();
+    // tracing_subscriber::fmt()
+    //     .with_max_level(tracing::Level::DEBUG)
+    //     .init();
 
-    // TODO: Move to init_server_state
-    let _tracer = opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_exporter(
-            opentelemetry_otlp::new_exporter().tonic().with_endpoint(
-                serve_command
-                    .otlp_endpoint
-                    .unwrap_or(OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT.into()),
-            ),
-        )
-        .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
-            opentelemetry_sdk::Resource::new(vec![
-                KeyValue::new(
-                    opentelemetry_semantic_conventions::resource::SERVICE_NAME,
-                    "ndc-hub",
-                ),
-                KeyValue::new(
-                    opentelemetry_semantic_conventions::resource::SERVICE_VERSION,
-                    env!("CARGO_PKG_VERSION"),
-                ),
-            ]),
-        ))
-        .install_batch(opentelemetry::runtime::Tokio);
-
-    let server_state = init_server_state::<C>(serve_command.configuration).await; // Shouldn't this be initialized prior to request handling?
+    let server_state = init_server_state::<C>(serve_command.configuration /*  , serve_command.otlp_endpoint */).await; // Shouldn't this be initialized prior to request handling?
 
     let router = create_router::<C>(server_state);
 
@@ -149,6 +129,8 @@ where
             tokio::signal::ctrl_c()
                 .await
                 .expect("unable to install signal handler");
+
+            opentelemetry::global::shutdown_tracer_provider();
         })
         .await?;
 
@@ -158,6 +140,7 @@ where
 /// Initialize the server state from the configuration file.
 pub async fn init_server_state<C: Connector + Clone + Default + 'static>(
     config_file: String,
+    // otlp_endpoint: Option<String>,
 ) -> ServerState<C>
 where
     C::RawConfiguration: DeserializeOwned + Sync + Send,
@@ -176,12 +159,53 @@ where
         .await
         .unwrap();
 
+    // let tracer = opentelemetry_otlp::new_pipeline()
+    //     .tracing()
+    //     .with_exporter(
+    //         opentelemetry_otlp::new_exporter().tonic().with_endpoint(
+    //             otlp_endpoint
+    //                 .unwrap_or(OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT.into()),
+    //         ),
+    //     )
+    //     .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
+    //         opentelemetry_sdk::Resource::new(vec![
+    //             KeyValue::new(
+    //                 opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+    //                 "ndc-hub",
+    //             ),
+    //             KeyValue::new(
+    //                 opentelemetry_semantic_conventions::resource::SERVICE_VERSION,
+    //                 env!("CARGO_PKG_VERSION"),
+    //             ),
+    //         ]),
+    //     ))
+    //     .install_batch(opentelemetry::runtime::Tokio)
+    //     .expect("failed to create tracer");
+
     ServerState::<C> {
         configuration,
         state,
         metrics,
+        // tracer:Arc::new(tracer),
     }
 }
+
+// // Example taken from https://docs.rs/axum/latest/axum/middleware/fn.from_fn_with_state.html
+// async fn otlp_middleware<B>(
+//     State(tracer): State<Arc<sdk::trace::Tracer>>,
+//     // you can add more extractors here but the last
+//     // extractor must implement `FromRequest` which
+//     // `Request` does
+//     request: Request<B>,
+//     next: Next<B>,
+// ) -> axum::response::Response {
+//     let response: Response<BoxBody> = tracer.in_span("request", |cx| async {
+//         // TODO: Enrich with MD about route, etc.
+//         next.run(request).await
+//     }).await;
+
+//     response
+// }
 
 pub fn create_router<'a, C: Connector + Clone + 'static>(state: ServerState<C>) -> Router
 where
@@ -189,6 +213,11 @@ where
     C::Configuration: Serialize + Clone + Sync + Send,
     C::State: Sync + Send + Clone,
 {
+
+    // let tracer = state.tracer.clone();
+
+    // * Pass tracing middleware struct in via ServerState.
+    // * Create OTel Trace Middleware w/ helper
     Router::new()
         .route("/capabilities", get(get_capabilities::<C>))
         .route("/health", get(get_health::<C>))
@@ -198,7 +227,21 @@ where
         .route("/explain", post(post_explain::<C>))
         .route("/mutation", post(post_mutation::<C>))
         .with_state(state)
-        .layer(TraceLayer::new_for_http())
+        .layer(
+            TraceLayer::new_for_http()
+            // .on_response(|response: &Response<BoxBody>, latency: Duration, span: &Span| {
+            //     // Using callback implementation as documented here: https://docs.rs/tower-http/0.4.1/tower_http/trace/index.html
+            //     // Unfortunately, there's extensive work required to make the request available in the on_response callback.
+            //     // Also, `in_span` is the tracer method documented, and this wants to wrap the execution, as opposed to append to the prior on_request trace.
+            //     tracing::debug!("response generated in {:?}", latency)
+            // })
+        )
+        // .layer(from_fn_with_state(tracer, otlp_middleware))
+        // * Add as .layer
+        .layer(response_with_trace_layer())
+        // set up `TraceLayer` from tower-http
+        .layer(opentelemetry_tracing_layer())
+
 }
 
 async fn get_metrics<C: Connector>(

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -154,7 +154,6 @@ where
         configuration,
         state,
         metrics,
-        // tracer:Arc::new(tracer),
     }
 }
 

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -110,6 +110,7 @@ where
         .with_max_level(tracing::Level::DEBUG)
         .init();
 
+    // TODO: Move to init_server_state
     let _tracer = opentelemetry_otlp::new_pipeline()
         .tracing()
         .with_exporter(
@@ -133,7 +134,7 @@ where
         ))
         .install_batch(opentelemetry::runtime::Tokio);
 
-    let server_state = init_server_state::<C>(serve_command.configuration).await;
+    let server_state = init_server_state::<C>(serve_command.configuration).await; // Shouldn't this be initialized prior to request handling?
 
     let router = create_router::<C>(server_state);
 

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -53,7 +53,6 @@ pub struct ServerState<C: Connector> {
     configuration: C::Configuration,
     state: C::State,
     metrics: Registry,
-    // tracer: Arc<sdk::trace::Tracer>,
 }
 
 /// A default main function for a connector.

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -10,7 +10,7 @@ use ndc_client::models::{
     CapabilitiesResponse, ExplainResponse, MutationRequest, MutationResponse, QueryRequest,
     QueryResponse, SchemaResponse,
 };
-use opentelemetry_otlp::{OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT};
+
 // use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::Tracer};
 use prometheus::Registry;
 use serde::{de::DeserializeOwned, Serialize};

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -105,6 +105,7 @@ where
     C::State: Sync + Send + Clone,
 {
     // Set endpoint ENV picked up by macros in `traces` crate via CLI option if used
+    // TODO: Check that tracing library doesn't have a better way to do this.
     serve_command.otlp_endpoint.map(|e| {
         env::set_var(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, e);
     });

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -106,12 +106,6 @@ where
     C::Configuration: Serialize + DeserializeOwned + Sync + Send + Clone,
     C::State: Sync + Send + Clone,
 {
-    // global::set_text_map_propagator(TraceContextPropagator::new());
-
-    // tracing_subscriber::fmt()
-    //     .with_max_level(tracing::Level::DEBUG)
-    //     .init();
-
     let server_state = init_server_state::<C>(serve_command.configuration /*  , serve_command.otlp_endpoint */).await; // Shouldn't this be initialized prior to request handling?
 
     let router = create_router::<C>(server_state);

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -43,7 +43,7 @@ struct ServeCommand {
     #[arg(long, value_name = "CONFIGURATION_FILE", env = "CONFIGURATION_FILE")]
     configuration: String,
     #[arg(long, value_name = "OTLP_ENDPOINT", env = "OTLP_ENDPOINT")]
-    otlp_endpoint: Option<String>, // TODO: Figure out if we want to use this, or use OTEL_EXPORTER_OTLP_TRACES_ENDPOINT instead
+    otlp_endpoint: Option<String>, // NOTE: `tracing` crate uses `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` ENV variable, but we want to control the endpoint via CLI interface
     #[arg(long, value_name = "PORT", env = "PORT")]
     port: Option<String>,
 }

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -132,7 +132,6 @@ where
 /// Initialize the server state from the configuration file.
 pub async fn init_server_state<C: Connector + Clone + Default + 'static>(
     config_file: String,
-    // otlp_endpoint: Option<String>,
 ) -> ServerState<C>
 where
     C::RawConfiguration: DeserializeOwned + Sync + Send,


### PR DESCRIPTION
This PR adopts the patterns used by https://github.com/hasura/mongo-agent-rs for OTEL tracing.

Heavy lifting is performed by the https://docs.rs/tracing crate.

### Open Questions

Should we get these errors if OTLP endpoint not set?

```
OpenTelemetry trace error occurred. request failed with status 404 Not Found
```

### Changes

TODO:

* [x] Trace all routes
* [x] Include V3 tags - Can be done through ENV: `OTEL_SERVICE_NAME ` and `OTEL_RESOURCE_ATTRIBUTES`
* [x] Test automatic tracing
* [x] Test correct nesting of manual traces (including across async boundaries)
* [ ] Automatic tests
* [x] Documentation - See Rob's V3 docs repo, Tracing.md
* [ ] Determine if GRPC, vs. HTTP should be selected or configurable
* [ ] Talk to Shahid about MT deployment changes for ENV changes

### Running the example agent

### Configuration

When authoring an agent using this SDK, the following run-time environment variables can be used to configure OTEL tracing:

(see https://github.com/TommyCpp/opentelemetry-rust/blob/7c5ad125cec85240909243092202f200ea843960/opentelemetry/src/sdk/resource/env.rs)

* `OTEL_RESOURCE_ATTRIBUTES` e.g. `key=value, k = v , a= x, a=z`
* `OTEL_SERVICE_NAME` e.g. `ndc_hub_example`
* `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` e.g. `http://localhost:4317`

### Manual Testing

Run Jager:

```bash
docker run --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:1.45
```

Run the example agent:

```bash
OTEL_SERVICE_NAME=ndc_hub_example OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317 cargo run --bin 
ndc_hub_example -- serve --configuration <(echo 'null')
```

Request the schema:

```bash
curl localhost:8100/schema | jq .
```

See results in Jager (http://localhost:16686/): 

![image](https://github.com/hasura/ndc-hub/assets/92299/37f9bb32-651d-4212-8021-24acf96c1572)
