### PR TITLE
Add `fetch_metrics` call for fetching metrics

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -180,6 +180,16 @@ pub trait Connector {
         metrics: &mut prometheus::Registry,
     ) -> Result<Self::State, InitializationError>;
 
+    /// Update any metrics from the state
+    ///
+    /// Useful to query a connection pool
+    /// and use it to update metrics
+    /// rather than polling with a timer
+    fn fetch_metrics(
+        state: &Self::State,
+        metrics: &prometheus::Registry,
+    ) -> Result<(), InitializationError>;
+
     /// Check the health of the connector.
     ///
     /// For example, this function should check that the connector
@@ -263,6 +273,13 @@ impl Connector for Example {
         _configuration: &Self::Configuration,
         _metrics: &mut prometheus::Registry,
     ) -> Result<Self::State, InitializationError> {
+        Ok(())
+    }
+
+    fn fetch_metrics(
+        _state: &Self::State,
+        _metrics: &prometheus::Registry,
+    ) -> Result<(), InitializationError> {
         Ok(())
     }
 

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -203,7 +203,7 @@ where
 async fn get_metrics<C: Connector>(
     State(state): State<ServerState<C>>,
 ) -> Result<String, StatusCode> {
-    routes::get_metrics::<C>(state.metrics, &state.state)
+    routes::get_metrics::<C>(&state.configuration, &state.state, state.metrics)
 }
 
 async fn get_capabilities<C: Connector>() -> Json<CapabilitiesResponse> {

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -203,7 +203,7 @@ where
 async fn get_metrics<C: Connector>(
     State(state): State<ServerState<C>>,
 ) -> Result<String, StatusCode> {
-    routes::get_metrics::<C>(state.metrics)
+    routes::get_metrics::<C>(state.metrics, &state.state)
 }
 
 async fn get_capabilities<C: Connector>() -> Json<CapabilitiesResponse> {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -5,14 +5,15 @@ use prometheus::{Encoder, Registry, TextEncoder};
 use crate::connector::{Connector, HealthError};
 
 pub fn get_metrics<C: Connector>(
-    metrics: Registry,
+    configuration: &C::Configuration,
     state: &C::State,
+    metrics: Registry,
 ) -> Result<String, StatusCode> {
     let mut buffer = vec![];
     let encoder = TextEncoder::new();
 
-    // ask the connector to update all it's metrics
-    C::fetch_metrics(state, &metrics).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    // Ask the connector to update all its metrics
+    C::fetch_metrics(configuration, state).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let metric_families = metrics.gather();
     encoder


### PR DESCRIPTION
When implementing metrics for Postgres NDC I found querying the connection pool a little trickier than I'd like. Because the connector had no idea when `/metrics` were being requested, I had to set up a timer thread to poll the connection pool every second or so, possibly needlessly.

This is a very rough sketch of an solution - the connector provides a function that takes the `State` plus the Prometheus `Registry` and updates all counters.