### PR TITLE
Add configuration server to default_main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ opentelemetry_sdk = "0.18.0"
 opentelemetry-otlp = "0.11.0"
 opentelemetry-semantic-conventions = "0.10.0"
 prometheus = "0.13.3"
-serde = "1.0.164"
+schemars = { version = "0.8.12", features = ["smol_str"] }
+serde = { version = "1.0.164", features = ["derive"] }
 serde_json = { version = "1.0.97", features = ["raw_value"] }
 thiserror = "1.0"
 tokio = { version =  "1.28.2", features = ["fs", "signal"] }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -16,8 +16,14 @@ pub enum ValidateError {
 
 #[derive(Debug)]
 pub struct InvalidRange {
-    pub path: Vec<String>,
+    pub path: Vec<KeyOrIndex>,
     pub message: String,
+}
+
+#[derive(Debug)]
+pub enum KeyOrIndex {
+    Key(String),
+    Index(u32),
 }
 
 /// Errors which occur when trying to validate connector

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -17,8 +17,8 @@ pub enum ValidateError {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct InvalidRange {
-    path: Vec<KeyOrIndex>,
-    message: String,
+    pub path: Vec<KeyOrIndex>,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use clap::Args;
 use ndc_client::models;
-use serde::de::DeserializeOwned;
 use std::{collections::BTreeMap, error::Error};
 use thiserror::Error;
 
@@ -167,7 +166,7 @@ pub enum MutationError {
 #[async_trait]
 pub trait Connector {
     /// The type of unvalidated, raw configuration, as provided by the user.
-    type RawConfiguration : DeserializeOwned + serde::Serialize;
+    type RawConfiguration;
     /// The type of validated configuration
     type Configuration;
     /// The type of unserializable state

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use clap::Args;
 use ndc_client::models;
+use serde::de::DeserializeOwned;
 use std::{collections::BTreeMap, error::Error};
 use thiserror::Error;
 
@@ -9,7 +10,23 @@ use thiserror::Error;
 ///
 /// See [`Connector::validate_raw_configuration`].
 #[derive(Debug, Error)]
-pub enum ConfigurationError {
+pub enum ValidateError {
+    #[error("error validating configuration: {0:?}")]
+    ValidateError(Vec<InvalidRange>),
+}
+
+#[derive(Debug)]
+pub struct InvalidRange {
+    pub path: Vec<String>,
+    pub message: String,
+}
+
+/// Errors which occur when trying to validate connector
+/// configuration.
+///
+/// See [`Connector::update_configuration`].
+#[derive(Debug, Error)]
+pub enum UpdateConfigurationError {
     #[error("error validating configuration: {0}")]
     Other(Box<dyn Error>),
 }
@@ -149,24 +166,24 @@ pub enum MutationError {
 /// connection string would be state.
 #[async_trait]
 pub trait Connector {
-    /// The type of command line arguments to generate a configuration
-    type ConfigureArgs;
     /// The type of unvalidated, raw configuration, as provided by the user.
-    type RawConfiguration;
+    type RawConfiguration : DeserializeOwned + serde::Serialize;
     /// The type of validated configuration
     type Configuration;
     /// The type of unserializable state
     type State;
 
-    async fn configure(
-        args: &Self::ConfigureArgs,
-    ) -> Result<Self::RawConfiguration, ConfigurationError>;
+    fn make_empty_configuration() -> Self::RawConfiguration;
+
+    async fn update_configuration(
+        config: &Self::RawConfiguration,
+    ) -> Result<Self::RawConfiguration, UpdateConfigurationError>;
 
     /// Validate the raw configuration provided by the user,
     /// returning a configuration error or a validated [`Connector::Configuration`].
     async fn validate_raw_configuration(
         configuration: &Self::RawConfiguration,
-    ) -> Result<Self::Configuration, ConfigurationError>;
+    ) -> Result<Self::Configuration, ValidateError>;
 
     /// Initialize the connector's in-memory state.
     ///
@@ -242,20 +259,23 @@ pub struct ExampleConfigureArgs {}
 
 #[async_trait]
 impl Connector for Example {
-    type ConfigureArgs = ExampleConfigureArgs;
     type RawConfiguration = ();
     type Configuration = ();
     type State = ();
 
-    async fn configure(
-        _args: &Self::ConfigureArgs,
-    ) -> Result<Self::RawConfiguration, ConfigurationError> {
+    fn make_empty_configuration() -> Self::RawConfiguration {
+        ()
+    }
+
+    async fn update_configuration(
+        _config: &Self::RawConfiguration,
+    ) -> Result<Self::RawConfiguration, UpdateConfigurationError> {
         Ok(())
     }
 
     async fn validate_raw_configuration(
         _configuration: &Self::Configuration,
-    ) -> Result<Self::Configuration, ConfigurationError> {
+    ) -> Result<Self::Configuration, ValidateError> {
         Ok(())
     }
 

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use ndc_client::models;
 use std::{collections::BTreeMap, error::Error};
 use thiserror::Error;
+use serde::Serialize;
 
 /// Errors which occur when trying to validate connector
 /// configuration.
@@ -14,13 +15,14 @@ pub enum ValidateError {
     ValidateError(Vec<InvalidRange>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize)]
 pub struct InvalidRange {
-    pub path: Vec<KeyOrIndex>,
-    pub message: String,
+    path: Vec<KeyOrIndex>,
+    message: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
 pub enum KeyOrIndex {
     Key(String),
     Index(u32),

--- a/src/default_main.rs
+++ b/src/default_main.rs
@@ -5,7 +5,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use ndc_client::models::{
     CapabilitiesResponse, ExplainResponse, MutationRequest, MutationResponse, QueryRequest,
     QueryResponse, SchemaResponse,
@@ -14,29 +14,24 @@ use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::{WithExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use prometheus::Registry;
+use schemars::{schema::RootSchema, JsonSchema};
 use serde::{de::DeserializeOwned, Serialize};
 use std::error::Error;
 use std::{env, net::SocketAddr};
 use tower_http::trace::TraceLayer;
 
 #[derive(Parser)]
-struct CliArgs<C: Connector>
-where
-    C::ConfigureArgs: Clone + Send + Sync + Args,
-{
+struct CliArgs {
     #[command(subcommand)]
-    command: Command<C>,
+    command: Command,
 }
 
 #[derive(Clone, Subcommand)]
-enum Command<C: Connector>
-where
-    C::ConfigureArgs: Clone + Send + Sync + Args,
-{
+enum Command {
     #[command(arg_required_else_help = true)]
     Serve(ServeCommand),
     #[command()]
-    GenerateConfiguration(C::ConfigureArgs),
+    Configuration(ConfigurationCommand),
 }
 
 #[derive(Clone, Parser)]
@@ -45,6 +40,24 @@ struct ServeCommand {
     configuration: String,
     #[arg(long, value_name = "OTLP_ENDPOINT", env = "OTLP_ENDPOINT")]
     otlp_endpoint: Option<String>,
+    #[arg(long, value_name = "PORT", env = "PORT")]
+    port: Option<String>,
+}
+
+#[derive(Clone, Parser)]
+struct ConfigurationCommand {
+    #[command(subcommand)]
+    command: ConfigurationSubcommand,
+}
+
+#[derive(Clone, Subcommand)]
+enum ConfigurationSubcommand {
+    #[command()]
+    Serve(ServeConfigurationCommand),
+}
+
+#[derive(Clone, Parser)]
+struct ServeConfigurationCommand {
     #[arg(long, value_name = "PORT", env = "PORT")]
     port: Option<String>,
 }
@@ -81,18 +94,15 @@ pub struct ServerState<C: Connector> {
 /// - Logs are written to stdout
 pub async fn default_main<C: Connector + Clone + Default + 'static>() -> Result<(), Box<dyn Error>>
 where
-    C::ConfigureArgs: Clone + Send + Sync + Args,
-    C::RawConfiguration: Serialize + DeserializeOwned + Sync + Send,
+    C::RawConfiguration: Serialize + DeserializeOwned + JsonSchema + Sync + Send,
     C::Configuration: Serialize + DeserializeOwned + Sync + Send + Clone,
     C::State: Sync + Send + Clone,
 {
-    let CliArgs { command } = CliArgs::<C>::parse();
+    let CliArgs { command } = CliArgs::parse();
 
     match command {
         Command::Serve(serve_command) => serve::<C>(serve_command).await,
-        Command::GenerateConfiguration(configure_command) => {
-            configure::<C>(configure_command).await
-        }
+        Command::Configuration(configure_command) => configuration::<C>(configure_command).await,
     }
 }
 
@@ -182,7 +192,7 @@ where
     }
 }
 
-pub fn create_router<'a, C: Connector + Clone + 'static>(state: ServerState<C>) -> Router
+pub fn create_router<C: Connector + Clone + 'static>(state: ServerState<C>) -> Router
 where
     C::RawConfiguration: DeserializeOwned + Sync + Send,
     C::Configuration: Serialize + Clone + Sync + Send,
@@ -241,14 +251,130 @@ async fn post_query<C: Connector>(
     routes::post_query::<C>(&state.configuration, &state.state, request).await
 }
 
-async fn configure<C: Connector + Clone + Default + 'static>(
-    args: C::ConfigureArgs,
+async fn configuration<C: Connector + 'static>(
+    command: ConfigurationCommand,
 ) -> Result<(), Box<dyn Error>>
 where
-    C::ConfigureArgs: Clone + Send + Sync + Args,
-    C::RawConfiguration: Serialize,
+    C::RawConfiguration: Serialize + DeserializeOwned + JsonSchema,
 {
-    let configuration = C::configure(&args).await?;
-    println!("{}", serde_json::to_string_pretty(&configuration)?);
+    match command.command {
+        ConfigurationSubcommand::Serve(serve_command) => {
+            serve_configuration::<C>(serve_command).await
+        }
+    }
+}
+
+async fn serve_configuration<C: Connector + 'static>(
+    serve_command: ServeConfigurationCommand,
+) -> Result<(), Box<dyn Error>>
+where
+    C::RawConfiguration: Serialize + DeserializeOwned + JsonSchema,
+{
+    let port = serve_command.port.unwrap_or("9100".into());
+    let address = SocketAddr::new("0.0.0.0".parse()?, port.parse()?);
+
+    println!("Starting server on {}", address);
+
+    let router = Router::new()
+        .route("/", get(get_empty::<C>).post(post_update::<C>))
+        .route("/schema", get(get_config_schema::<C>))
+        // .route("/validate", post(post_validate::<C>));
+        ;
+
+    axum::Server::bind(&address)
+        .serve(router.into_make_service())
+        .with_graceful_shutdown(async {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("unable to install signal handler");
+        })
+        .await?;
+
     Ok(())
 }
+
+async fn get_empty<C: Connector>() -> Json<C::RawConfiguration>
+where
+    C::RawConfiguration: Serialize,
+{
+    Json(C::make_empty_configuration())
+}
+
+async fn post_update<C: Connector>(
+    Json(configuration): Json<C::RawConfiguration>,
+) -> Result<Json<C::RawConfiguration>, StatusCode>
+where
+    C::RawConfiguration: Serialize + DeserializeOwned,
+{
+    Ok(Json(
+        C::update_configuration(&configuration)
+            .await
+            .map_err(|e| StatusCode::INTERNAL_SERVER_ERROR)?,
+    ))
+}
+
+async fn get_config_schema<C: Connector>() -> Json<RootSchema>
+where
+    C::RawConfiguration: JsonSchema,
+{
+    let schema = schemars::schema_for!(C::RawConfiguration);
+    Json(schema)
+}
+
+#[derive(serde::Deserialize)]
+struct ValidateRequest<C: Connector> {
+    configuration: C::RawConfiguration,
+}
+
+#[derive(Serialize)]
+struct ValidateResponse {
+    schema: SchemaResponse,
+}
+
+#[derive(Serialize)]
+struct ValidateErrors {
+    ranges: Vec<InvalidRange>,
+}
+
+#[derive(Serialize)]
+pub struct InvalidRange {
+    path: Vec<String>,
+    message: String,
+}
+
+async fn post_validate<'a, C: Connector>(
+    request: Json<ValidateRequest<C>>,
+) -> Result<Json<ValidateResponse>, (StatusCode, Json<ValidateErrors>)>
+where
+    C::RawConfiguration: DeserializeOwned,
+{
+    let configuration = C::validate_raw_configuration(&request.configuration)
+        .await
+        .map_err(|e| match e {
+            crate::connector::ValidateError::ValidateError(ranges) => (
+                StatusCode::BAD_REQUEST,
+                Json(ValidateErrors {
+                    ranges: ranges
+                        .into_iter()
+                        .map(|r| InvalidRange {
+                            path: r.path,
+                            message: r.message,
+                        })
+                        .collect(),
+                }),
+            ),
+        })?;
+    let schema = C::get_schema(&configuration).await.map_err(|e| todo!())?;
+    Ok(Json(ValidateResponse { schema }))
+}
+
+// async fn configure<C: Connector + Clone + Default + 'static>(
+//     args: GenerateConfigurationCommand,
+// ) -> Result<(), Box<dyn Error>>
+// where
+//     C::RawConfiguration: DeserializeOwned + Serialize,
+// {
+//     let configuration = C::update_configuration(&args).await?;
+//     println!("{}", serde_json::to_string_pretty(&configuration)?);
+//     Ok(())
+// }


### PR DESCRIPTION
This adds a configuration server to `default_main` which can be run using `cargo run -- configuration serve`:

```sh
> cargo run -- configuration serve
Starting server on 0.0.0.0:9100

> # Get a minimal configuration
> curl http://0.0.0.0:9100              
null

> # Elaborate a configuration
> curl http://0.0.0.0:9100 -X POST -H 'Content-Type: application/json' -d 'null'       
null

> # Validate configuration
> curl http://0.0.0.0:9100/validate -X POST -H 'Content-Type: application/json' -d 'null' | jq .
{
  "schema": {
    "scalar_types": {},
    "object_types": {},
    "collections": [],
    "functions": [],
    "procedures": []
  }
}

> # Get the JSON schema for the configuration
> curl http://0.0.0.0:9100/schema | jq .    
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Null",
  "type": "null"
}
```