### PR TITLE
feat: re-export ndc-client model types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod connector;
 pub mod default_main;
 pub mod routes;
+
+pub use ndc_client::models;


### PR DESCRIPTION
The Connector trait uses model types from ndc-client in its signatures, but before this change ndc-hub does not re-export those types. That means that projects using ndc-hub also needed a direct dependency on ndc-client. That is complicated by the fact that the ndc-hub Cargo.toml locks a specific git hash for its ndc-client dependency. A consumer of ndc-hub would have to copy the same git hash in its Cargo.toml to avoid multiple copies of ndc-client, and would have to update that hash whenever the hash in ndc-hub changes.

Re-exporting types sidesteps this problem - consumers of ndc-hub no longer need to list ndc-client as a dependency. This way models can be imported as `use ndc_hub::models::CapabilitiesResponse;`

But I also want to argue that ndc-hub *should not* lock a revision of ndc-client in Cargo.toml, and generally should not use exact version numbers for any of its dependencies. Ndc-hub is a library, and exact version dependencies make it a pain to use a library because you have to copy the exact same version numbers into the consuming Cargo.toml. Libraries should use generous version bounds in Cargo.toml!

For example, instead of,

    serde = { version = "1.0.164", features = ["derive"] }

do this,

    serde = { version = "1", features = ["derive"] }