### PR TITLE
Expose a way to call `default_main` with a configuration file

### DIFF
--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -36,7 +36,7 @@ struct CliArgs {
 }
 
 #[derive(Clone, Subcommand)]
-pub enum Command {
+enum Command {
     #[command(arg_required_else_help = true)]
     Serve(ServeCommand),
     #[command()]
@@ -44,7 +44,7 @@ pub enum Command {
 }
 
 #[derive(Clone, Parser)]
-pub struct ServeCommand {
+struct ServeCommand {
     #[arg(long, value_name = "CONFIGURATION_FILE", env = "CONFIGURATION_FILE")]
     configuration: String,
     #[arg(long, value_name = "OTLP_ENDPOINT", env = "OTLP_ENDPOINT")]
@@ -54,7 +54,7 @@ pub struct ServeCommand {
 }
 
 #[derive(Clone, Parser)]
-pub struct ConfigurationCommand {
+struct ConfigurationCommand {
     #[command(subcommand)]
     command: ConfigurationSubcommand,
 }


### PR DESCRIPTION
It would be very useful for testing if we could run a `default_main` command with hardcoded arguments, rather than pulling from the CLI. So we don't break all the other connectors, this PR introduces a second function which allows us to run the same code as `default_main` but using a configuration file path to build the `Serve` command. We've tried to factor out the common code between the two, too.