### PR TITLE
Add a command that checks the server's health on the port provided.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -2034,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,7 @@ dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
  "prometheus",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
@@ -1349,9 +1350,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -2268,9 +2269,10 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "rust-connector-sdk",
 ]

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -28,6 +28,7 @@ opentelemetry-otlp = { version = "0.13.0", features = [
 ] }
 opentelemetry-semantic-conventions = "0.12.0"
 prometheus = "0.13.3"
+reqwest = "0.11.20"
 schemars = { version = "0.8.12", features = ["smol_str"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = { version = "1.0.97", features = ["raw_value"] }

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -44,3 +44,4 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
   "json",
 ] }
 tracing-opentelemetry = "0.20.0"
+url = "2.4.1"

--- a/rust-connector-sdk/bin/main.rs
+++ b/rust-connector-sdk/bin/main.rs
@@ -1,10 +1,19 @@
-use ndc_sdk::{connector::example::Example, default_main::default_main};
+use std::process::ExitCode;
+
+use ndc_sdk::connector::example::Example;
+use ndc_sdk::default_main::default_main;
 
 /// Run the [`Example`] connector using the [`default_main`]
 /// function, which accepts standard configuration options
 /// via the command line, configures metrics and trace
 /// collection, and starts a server.
 #[tokio::main]
-pub async fn main() {
-    default_main::<Example>().await.unwrap()
+pub async fn main() -> ExitCode {
+    match default_main::<Example>().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{}", err);
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/rust-connector-sdk/src/check_health.rs
+++ b/rust-connector-sdk/src/check_health.rs
@@ -1,7 +1,6 @@
-use std::net;
-
 #[derive(Debug)]
 pub enum HealthCheckError {
+    ParseError(url::ParseError),
     RequestError(reqwest::Error),
     UnsuccessfulResponse {
         status: reqwest::StatusCode,
@@ -12,6 +11,7 @@ pub enum HealthCheckError {
 impl std::fmt::Display for HealthCheckError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            HealthCheckError::ParseError(inner) => write!(f, "URL parse error: {}", inner),
             HealthCheckError::RequestError(inner) => write!(f, "request error: {}", inner),
             HealthCheckError::UnsuccessfulResponse { status, body } => {
                 write!(
@@ -26,8 +26,17 @@ impl std::fmt::Display for HealthCheckError {
 
 impl std::error::Error for HealthCheckError {}
 
-pub async fn check_health(socket: net::SocketAddr) -> Result<(), HealthCheckError> {
-    let url = format!("http://{}/health", socket);
+pub async fn check_health(host: Option<String>, port: u16) -> Result<(), HealthCheckError> {
+    let url = (|| -> Result<url::Url, url::ParseError> {
+        let mut url = reqwest::Url::parse("http://localhost/").unwrap(); // cannot fail
+        if let Some(host) = host {
+            url.set_host(Some(&host))?;
+        }
+        url.set_port(Some(port)).unwrap(); // canont fail for HTTP URLs
+        url.set_path("/health");
+        Ok(url)
+    })()
+    .map_err(HealthCheckError::ParseError)?;
     let response = reqwest::get(url)
         .await
         .map_err(HealthCheckError::RequestError)?;

--- a/rust-connector-sdk/src/check_health.rs
+++ b/rust-connector-sdk/src/check_health.rs
@@ -3,15 +3,22 @@ use std::net;
 #[derive(Debug)]
 pub enum HealthCheckError {
     RequestError(reqwest::Error),
-    UnsuccessfulResponse(reqwest::StatusCode),
+    UnsuccessfulResponse {
+        status: reqwest::StatusCode,
+        body: String,
+    },
 }
 
 impl std::fmt::Display for HealthCheckError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             HealthCheckError::RequestError(inner) => write!(f, "request error: {}", inner),
-            HealthCheckError::UnsuccessfulResponse(status) => {
-                write!(f, "unsuccessful response with status code: {}", status)
+            HealthCheckError::UnsuccessfulResponse { status, body } => {
+                write!(
+                    f,
+                    "unsuccessful response with status code: {}\nbody:\n{}",
+                    status, body
+                )
             }
         }
     }
@@ -25,9 +32,13 @@ pub async fn check_health(socket: net::SocketAddr) -> Result<(), HealthCheckErro
         .await
         .map_err(HealthCheckError::RequestError)?;
     let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(HealthCheckError::RequestError)?;
     if status.is_success() {
         Ok(())
     } else {
-        Err(HealthCheckError::UnsuccessfulResponse(status))
+        Err(HealthCheckError::UnsuccessfulResponse { status, body })
     }
 }

--- a/rust-connector-sdk/src/check_health.rs
+++ b/rust-connector-sdk/src/check_health.rs
@@ -1,0 +1,33 @@
+use std::net;
+
+#[derive(Debug)]
+pub enum HealthCheckError {
+    RequestError(reqwest::Error),
+    UnsuccessfulResponse(reqwest::StatusCode),
+}
+
+impl std::fmt::Display for HealthCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HealthCheckError::RequestError(inner) => write!(f, "request error: {}", inner),
+            HealthCheckError::UnsuccessfulResponse(status) => {
+                write!(f, "unsuccessful response with status code: {}", status)
+            }
+        }
+    }
+}
+
+impl std::error::Error for HealthCheckError {}
+
+pub async fn check_health(socket: net::SocketAddr) -> Result<(), HealthCheckError> {
+    let url = format!("http://{}/health", socket);
+    let response = reqwest::get(url)
+        .await
+        .map_err(HealthCheckError::RequestError)?;
+    let status = response.status();
+    if status.is_success() {
+        Ok(())
+    } else {
+        Err(HealthCheckError::UnsuccessfulResponse(status))
+    }
+}

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -15,9 +15,7 @@ impl Connector for Example {
     type Configuration = ();
     type State = ();
 
-    fn make_empty_configuration() -> Self::RawConfiguration {
-        ()
-    }
+    fn make_empty_configuration() -> Self::RawConfiguration {}
 
     async fn update_configuration(
         _config: &Self::RawConfiguration,
@@ -73,7 +71,6 @@ impl Connector for Example {
     ) -> Result<models::SchemaResponse, SchemaError> {
         async {
             info_span!("inside tracing example");
-            return ();
         }
         .instrument(info_span!("tracing example"))
         .await;

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -47,7 +47,7 @@ impl Connector for Example {
         _configuration: &Self::Configuration,
         _state: &Self::State,
     ) -> Result<(), HealthError> {
-        Err(HealthError::Other("Nah.".into()))
+        Ok(())
     }
 
     async fn get_capabilities() -> models::CapabilitiesResponse {

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -47,7 +47,7 @@ impl Connector for Example {
         _configuration: &Self::Configuration,
         _state: &Self::State,
     ) -> Result<(), HealthError> {
-        Ok(())
+        Err(HealthError::Other("Nah.".into()))
     }
 
     async fn get_capabilities() -> models::CapabilitiesResponse {

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -77,6 +77,8 @@ struct ServeConfigurationCommand {
 
 #[derive(Clone, Parser)]
 struct CheckHealthCommand {
+    #[arg(long, value_name = "HOST")]
+    host: Option<String>,
     #[arg(long, value_name = "PORT", env = "PORT", default_value = "8100")]
     port: Port,
 }
@@ -412,10 +414,9 @@ where
 }
 
 async fn check_health(
-    CheckHealthCommand { port }: CheckHealthCommand,
+    CheckHealthCommand { host, port }: CheckHealthCommand,
 ) -> Result<(), Box<dyn Error>> {
-    let socket = net::SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::LOCALHOST), port);
-    match check_health::check_health(socket).await {
+    match check_health::check_health(host, port).await {
         Ok(()) => {
             println!("Health check succeeded.");
             Ok(())

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -415,11 +415,11 @@ async fn check_health(
     let socket = net::SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::LOCALHOST), port);
     match check_health::check_health(socket).await {
         Ok(()) => {
-            eprintln!("Health check succeeded.");
+            println!("Health check succeeded.");
             Ok(())
         }
         Err(err) => {
-            eprintln!("Health check failed.");
+            println!("Health check failed.");
             Err(err.into())
         }
     }

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -264,7 +264,9 @@ async fn get_capabilities<C: Connector>() -> Json<CapabilitiesResponse> {
     routes::get_capabilities::<C>().await
 }
 
-async fn get_health<C: Connector>(State(state): State<ServerState<C>>) -> StatusCode {
+async fn get_health<C: Connector>(
+    State(state): State<ServerState<C>>,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     routes::get_health::<C>(&state.configuration, &state.state).await
 }
 

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -415,11 +415,11 @@ async fn check_health(
     let socket = net::SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::LOCALHOST), port);
     match check_health::check_health(socket).await {
         Ok(()) => {
-            println!("Health check succeeded.");
+            eprintln!("Health check succeeded.");
             Ok(())
         }
         Err(err) => {
-            println!("Health check failed with {}", err);
+            eprintln!("Health check failed.");
             Err(err.into())
         }
     }

--- a/rust-connector-sdk/src/lib.rs
+++ b/rust-connector-sdk/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod check_health;
 pub mod connector;
 pub mod default_main;
 pub mod routes;


### PR DESCRIPTION
### Why

This allows us to add health checks to any `ndc-sdk`-based connector's Docker image without having to bundle `curl`.

### What

I added a `check-health` command that checks `<HOST>:<PORT>/health` and prints an error if it fails. It defaults to `localhost:8100`, and uses the `PORT` environment variable if it's set, for easier `exec`-ing inside a Docker container.

I also modified the `/health` endpoint to report the error given in the response body.

### How

It does this by checking that the HTTP status code is successful.

I also tidied up some other bits and bobs that got in my way.