### PR TITLE
Add support for OpenTelemetry logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,6 @@ dependencies = [
  "axum",
  "axum-macros",
  "clap",
- "log",
  "ndc-client",
  "opentelemetry",
  "opentelemetry-appender-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,9 +802,6 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "matchers"
@@ -908,7 +905,6 @@ dependencies = [
  "clap",
  "ndc-client",
  "opentelemetry",
- "opentelemetry-appender-log",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_api",
@@ -1024,16 +1020,6 @@ checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-appender-log"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd820844a1b8339c91bca25ac389411c1854d30a3e0a55576c2138e11a76ddf"
-dependencies = [
- "log",
- "opentelemetry_api",
 ]
 
 [[package]]
@@ -2081,12 +2067,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "value-bag"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,9 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "matchers"
@@ -903,8 +906,10 @@ dependencies = [
  "axum",
  "axum-macros",
  "clap",
+ "log",
  "ndc-client",
  "opentelemetry",
+ "opentelemetry-appender-log",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_api",
@@ -1020,6 +1025,16 @@ checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-appender-log"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd820844a1b8339c91bca25ac389411c1854d30a3e0a55576c2138e11a76ddf"
+dependencies = [
+ "log",
+ "opentelemetry_api",
 ]
 
 [[package]]
@@ -2067,6 +2082,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
 name = "vcpkg"

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -16,7 +16,6 @@ async-trait = "0.1.68"
 axum = "0.6.18"
 axum-macros = "0.3.7"
 clap = { version = "4.3.9", features = ["derive", "env"] }
-log = {version = "0.4.17"}
 ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.3" }
 opentelemetry = { version = "0.20", features = [
   "rt-tokio",

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -22,7 +22,6 @@ opentelemetry = { version = "0.20", features = [
   "trace",
   "logs"
 ], default-features = false }
-opentelemetry-appender-log = { version = "0.1.0", default-features = false }
 opentelemetry_sdk = "0.20.0"
 opentelemetry_api = "0.20.0"
 opentelemetry-otlp = { version = "0.13.0", features = [

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -16,14 +16,18 @@ async-trait = "0.1.68"
 axum = "0.6.18"
 axum-macros = "0.3.7"
 clap = { version = "4.3.9", features = ["derive", "env"] }
+log = {version = "0.4.17"}
 ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.3" }
 opentelemetry = { version = "0.20", features = [
   "rt-tokio",
   "trace",
+  "logs"
 ], default-features = false }
+opentelemetry-appender-log = { version = "0.1.0", default-features = false }
 opentelemetry_sdk = "0.20.0"
 opentelemetry_api = "0.20.0"
 opentelemetry-otlp = { version = "0.13.0", features = [
+    "logs",
     "reqwest-client",
 ] }
 opentelemetry-semantic-conventions = "0.12.0"

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
+use opentelemetry::logs::Logger;
+use opentelemetry::logs::LoggerProvider;
 use tracing::info_span;
 use tracing::Instrument;
 
@@ -47,6 +49,20 @@ impl Connector for Example {
         _configuration: &Self::Configuration,
         _state: &Self::State,
     ) -> Result<(), HealthError> {
+        // emit an OpenTelemetry log
+        let provider = opentelemetry::global::logger_provider();
+
+        let logger = provider.logger("ndc_hub_example");
+
+        let log_record = opentelemetry::logs::LogRecordBuilder::new()
+            .with_severity_number(opentelemetry::logs::Severity::Info)
+            .with_attribute("event.name", "health-check-success")
+            .with_attribute("event.domain", "database")
+            .with_body("Health check OK!".into())
+            .build();
+
+        logger.emit(log_record);
+
         Ok(())
     }
 

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use opentelemetry::logs::Logger;
 use opentelemetry::logs::LoggerProvider;
+use opentelemetry::trace::TraceContextExt;
 use tracing::info_span;
 use tracing::Instrument;
 
@@ -54,8 +55,11 @@ impl Connector for Example {
 
         let logger = provider.logger("ndc_hub_example");
 
+        let context = opentelemetry::Context::current();
+
         let log_record = opentelemetry::logs::LogRecordBuilder::new()
             .with_severity_number(opentelemetry::logs::Severity::Info)
+            .with_span_context(context.span().span_context())
             .with_attribute("event.name", "health-check-success")
             .with_attribute("event.domain", "database")
             .with_body("Health check OK!".into())

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -11,7 +11,6 @@ use ndc_client::models::{
 };
 use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
 use opentelemetry_api::KeyValue;
-use opentelemetry_appender_log::OpenTelemetryLogBridge;
 use opentelemetry_otlp::{WithExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT};
 use opentelemetry_sdk::trace::Sampler;
 use prometheus::Registry;
@@ -178,9 +177,7 @@ fn init_tracing(serve_command: &ServeCommand) -> Result<(), Box<dyn Error>> {
         )
         .build();
 
-    // configure the `log` crate to output via OpenTelemetry
-    let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
-    log::set_boxed_logger(Box::new(otel_log_appender)).unwrap();
+    global::set_logger_provider(logger_provider);
 
     tracing_subscriber::registry()
         .with(


### PR DESCRIPTION
Adds support for [OpenTelemetry Logs](https://opentelemetry.io/docs/specs/otel/logs/) (as opposed to the support we currently have for traces).

We want to use these for alerting important events, such as startup failures due to connection pool timeouts.