### PR TITLE
Adding SERVICE_TOKEN_SECRET to Rust SDK Serve command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,7 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0.164", features = ["derive"] }
 serde_json = { version = "1.0.97", features = ["raw_value"] }
 thiserror = "1.0"
 tokio = { version =  "1.28.2", features = ["fs", "signal"] }
-tower-http = { version = "0.4.1", features = ["cors", "trace"] }
+tower-http = { version = "0.4.1", features = ["cors", "trace", "validate-request"] }
 tracing = "0.1.37"
 uuid = "1.3.4"
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -206,6 +206,7 @@ where
                 let auth_header = request.headers().get("Authorization")
                     .map(|v| v.clone());
 
+                // NOTE: The comparison should probably be more permissive to allow for whitespace, etc.
                 if auth_header == expected_auth_header { return Ok(()); }
                 Err((StatusCode::UNAUTHORIZED, "").into_response())
             })

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -55,6 +55,8 @@ struct ServeCommand {
     otlp_endpoint: Option<String>, // NOTE: `tracing` crate uses `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` ENV variable, but we want to control the endpoint via CLI interface
     #[arg(long, value_name = "PORT", env = "PORT", default_value = "8100")]
     port: Port,
+    #[arg(long, value_name = "SERVICE_TOKEN_SECRET", env = "SERVICE_TOKEN_SECRET")]
+    service_token_secret: Option<String>,
 }
 
 #[derive(Clone, Parser)]

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -193,7 +193,7 @@ where
     let server_state = init_server_state::<C>(serve_command.configuration).await;
 
     let expected_auth_header: Option<HeaderValue> = serve_command.service_token_secret.and_then(|service_token_secret| {
-        let expected_bearer = format!("Bearer {}", service_token_secret); // TODO
+        let expected_bearer = format!("Bearer {}", service_token_secret);
         HeaderValue::from_str(&expected_bearer).ok()
     }); 
 

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -4,10 +4,12 @@ use std::net;
 
 use axum::{
     extract::State,
-    http::StatusCode,
+    http::{StatusCode, Request, HeaderValue},
     routing::{get, post},
-    Json, Router,
+    Json, Router, body::Body, response::IntoResponse,
 };
+use tower_http::validate_request::ValidateRequestHeaderLayer;
+
 use clap::{Parser, Subcommand};
 use ndc_client::models::{
     CapabilitiesResponse, ErrorResponse, ExplainResponse, MutationRequest, MutationResponse,
@@ -190,9 +192,24 @@ where
 
     let server_state = init_server_state::<C>(serve_command.configuration).await;
 
-    let router = create_router::<C>(server_state).layer(
-        TraceLayer::new_for_http().make_span_with(DefaultMakeSpan::default().level(Level::INFO)),
-    );
+    let expected_auth_header: Option<HeaderValue> = serve_command.service_token_secret.and_then(|service_token_secret| {
+        let expected_bearer = format!("Bearer {}", service_token_secret); // TODO
+        HeaderValue::from_str(&expected_bearer).ok()
+    }); 
+
+    let router = create_router::<C>(server_state)
+        .layer(
+            TraceLayer::new_for_http().make_span_with(DefaultMakeSpan::default().level(Level::INFO)),
+        ).layer(
+            ValidateRequestHeaderLayer::custom(move |request: &mut Request<Body>| {
+                // Validate the request
+                let auth_header = request.headers().get("Authorization")
+                    .map(|v| v.clone());
+
+                if auth_header == expected_auth_header { return Ok(()); }
+                Err((StatusCode::UNAUTHORIZED, "").into_response())
+            })
+        );
 
     let port = serve_command.port;
     let address = net::SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::UNSPECIFIED), port);


### PR DESCRIPTION
This is to be used in conjunction with the changes made to V3 engine that can send a pre-shared secret token via `Authorization: Bearer TOKEN` header.

If the `SERVICE_TOKEN_SECRET` env variable is set or the engine sends the `Authorization: Bearer SERVICE_TOKEN_SECRET` header, then the values must match.

If they do not match then the response will be StatusCode::UNAUTHORIZED.

If neither are set then the request proceeds as before.