### PR TITLE
Handle a SIGTERM correctly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.3#2ec596686e4ba76c055944eecffcd3f650387d98"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.4#38e19b0cfe0518c08bfcf486507de2a67e08b30e"
 dependencies = [
  "async-trait",
  "indexmap",

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -200,18 +200,20 @@ where
     axum::Server::bind(&address)
         .serve(router.into_make_service())
         .with_graceful_shutdown(async {
+            // wait for a SIGINT, i.e. a Ctrl+C from the keyboard
             let sigint = async {
                 tokio::signal::ctrl_c()
                     .await
                     .expect("unable to install signal handler")
             };
+            // wait for a SIGTERM, i.e. a normal `kill` command
             let sigterm = async {
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                     .expect("failed to install signal handler")
                     .recv()
-                    .await;
+                    .await
             };
-
+            // block until either of the above happens
             tokio::select! {
                 _ = sigint => (),
                 _ = sigterm => (),


### PR DESCRIPTION
Docker containers are stopped by sending a SIGTERM. Ideally we would catch this and shut down gracefully rather just collapsing, or ignoring it and waiting for the SIGKILL 10 seconds later.