### PR TITLE
add `region_routing` in `validate_raw_configuration`

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use ndc_client::models;
 use serde::Serialize;
-use std::error::Error;
+use std::{collections::BTreeMap, error::Error};
 use thiserror::Error;
 pub mod example;
 
@@ -189,6 +189,10 @@ pub trait Connector {
     /// The type of unserializable state
     type State;
 
+    fn get_read_regions(config: &Self::Configuration) -> Vec<String>;
+
+    fn get_write_regions(config: &Self::Configuration) -> Vec<String>;
+
     fn make_empty_configuration() -> Self::RawConfiguration;
 
     async fn update_configuration(
@@ -199,6 +203,7 @@ pub trait Connector {
     /// returning a configuration error or a validated [`Connector::Configuration`].
     async fn validate_raw_configuration(
         configuration: &Self::RawConfiguration,
+        region_routing: &BTreeMap<String, Vec<String>>,
     ) -> Result<Self::Configuration, ValidateError>;
 
     /// Initialize the connector's in-memory state.

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -17,6 +17,14 @@ impl Connector for Example {
 
     fn make_empty_configuration() -> Self::RawConfiguration {}
 
+    fn get_read_regions(_config: &Self::Configuration) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn get_write_regions(_config: &Self::Configuration) -> Vec<String> {
+        Vec::new()
+    }
+
     async fn update_configuration(
         _config: &Self::RawConfiguration,
     ) -> Result<Self::RawConfiguration, UpdateConfigurationError> {
@@ -25,6 +33,7 @@ impl Connector for Example {
 
     async fn validate_raw_configuration(
         _configuration: &Self::Configuration,
+        _region_routing: &BTreeMap<String, Vec<String>>,
     ) -> Result<Self::Configuration, ValidateError> {
         Ok(())
     }

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -28,8 +28,8 @@ use opentelemetry_sdk::trace::Sampler;
 use prometheus::Registry;
 use schemars::{schema::RootSchema, JsonSchema};
 use serde::{de::DeserializeOwned, Serialize};
-use std::error::Error;
 use std::net;
+use std::{collections::BTreeMap, error::Error};
 use std::{env, process::exit};
 use tower_http::{
     cors::CorsLayer,
@@ -291,7 +291,7 @@ where
     let configuration_json = std::fs::read_to_string(config_file).unwrap();
     let raw_configuration =
         serde_json::de::from_str::<C::RawConfiguration>(configuration_json.as_str()).unwrap();
-    let configuration = C::validate_raw_configuration(&raw_configuration)
+    let configuration = C::validate_raw_configuration(&raw_configuration, &BTreeMap::default())
         .await
         .unwrap();
 
@@ -464,7 +464,7 @@ async fn post_validate<C: Connector>(
 where
     C::RawConfiguration: DeserializeOwned,
 {
-    let configuration = C::validate_raw_configuration(&configuration)
+    let configuration = C::validate_raw_configuration(&configuration, &BTreeMap::default())
         .await
         .map_err(|e| match e {
             crate::connector::ValidateError::ValidateError(ranges) => (
@@ -527,7 +527,7 @@ where
     let configuration_json = std::fs::read_to_string(command.configuration).unwrap();
     let raw_configuration =
         serde_json::de::from_str::<C::RawConfiguration>(configuration_json.as_str()).unwrap();
-    let configuration = C::validate_raw_configuration(&raw_configuration)
+    let configuration = C::validate_raw_configuration(&raw_configuration, &BTreeMap::default())
         .await
         .unwrap();
 


### PR DESCRIPTION
## Description

This PR adds `region_routings` as an argument to `validate_raw_configuration`. The `validate_raw_configuration` is supposed to create `Configuration` from `RawConfiguration`, but `Configuration` needs `region_routings`, which is not there in `RawConfiguration`.

This PR also adds functions to extract read and write regions from `Configuration`.

Please note that this is required for the multi-region routing project (see specs [here](https://docs.google.com/document/d/1qV8ZDxbnKzNn599eA_WbH3EU8z1aqQJN-RdQL1vF7W4/edit#heading=h.mmvzpxnp73aw))