### PR TITLE
chore: remove `raw_region_routing`

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use ndc_client::models;
 use serde::Serialize;
-use std::{collections::BTreeMap, error::Error};
+use std::error::Error;
 use thiserror::Error;
 pub mod example;
 
@@ -189,9 +189,15 @@ pub trait Connector {
     /// The type of unserializable state
     type State;
 
-    fn get_read_regions(config: &Self::Configuration) -> Vec<String>;
+    /// Return any read regions defined in the connector's configuration
+    fn get_read_regions(_config: &Self::Configuration) -> Vec<String> {
+        vec![]
+    }
 
-    fn get_write_regions(config: &Self::Configuration) -> Vec<String>;
+    /// Return any write regions defined in the connector's configuration
+    fn get_write_regions(_config: &Self::Configuration) -> Vec<String> {
+        vec![]
+    }
 
     fn make_empty_configuration() -> Self::RawConfiguration;
 
@@ -203,7 +209,6 @@ pub trait Connector {
     /// returning a configuration error or a validated [`Connector::Configuration`].
     async fn validate_raw_configuration(
         configuration: &Self::RawConfiguration,
-        region_routing: &BTreeMap<String, Vec<String>>,
     ) -> Result<Self::Configuration, ValidateError>;
 
     /// Initialize the connector's in-memory state.

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -33,7 +33,6 @@ impl Connector for Example {
 
     async fn validate_raw_configuration(
         _configuration: &Self::Configuration,
-        _region_routing: &BTreeMap<String, Vec<String>>,
     ) -> Result<Self::Configuration, ValidateError> {
         Ok(())
     }

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -28,8 +28,8 @@ use opentelemetry_sdk::trace::Sampler;
 use prometheus::Registry;
 use schemars::{schema::RootSchema, JsonSchema};
 use serde::{de::DeserializeOwned, Serialize};
+use std::error::Error;
 use std::net;
-use std::{collections::BTreeMap, error::Error};
 use std::{env, process::exit};
 use tower_http::{
     cors::CorsLayer,
@@ -301,7 +301,7 @@ where
     let configuration_json = std::fs::read_to_string(config_file).unwrap();
     let raw_configuration =
         serde_json::de::from_str::<C::RawConfiguration>(configuration_json.as_str()).unwrap();
-    let configuration = C::validate_raw_configuration(&raw_configuration, &BTreeMap::default())
+    let configuration = C::validate_raw_configuration(&raw_configuration)
         .await
         .unwrap();
 
@@ -474,7 +474,7 @@ async fn post_validate<C: Connector>(
 where
     C::RawConfiguration: DeserializeOwned,
 {
-    let configuration = C::validate_raw_configuration(&configuration, &BTreeMap::default())
+    let configuration = C::validate_raw_configuration(&configuration)
         .await
         .map_err(|e| match e {
             crate::connector::ValidateError::ValidateError(ranges) => (
@@ -537,7 +537,7 @@ where
     let configuration_json = std::fs::read_to_string(command.configuration).unwrap();
     let raw_configuration =
         serde_json::de::from_str::<C::RawConfiguration>(configuration_json.as_str()).unwrap();
-    let configuration = C::validate_raw_configuration(&raw_configuration, &BTreeMap::default())
+    let configuration = C::validate_raw_configuration(&raw_configuration)
         .await
         .unwrap();
 


### PR DESCRIPTION
We will not need this information during `validate_raw_configuration`, as it will only be provided by the Metadata Build Service at runtime, so removing these extra items.

Also adds default implementations for `get_read_regions` and `get_write_regions` so that NDC agents that don't care about that stuff don't have to concern themselves with it.