### PR TITLE
wip: Use TokioCurrentThread runtime for otel trace batching

### DIFF
--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "^4.3.9", features = ["derive", "env"] }
 ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.5" }
 ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.5" }
 opentelemetry = { version = "^0.20", features = [
-  "rt-tokio",
+  "rt-tokio-current-thread",
   "trace",
 ], default-features = false }
 opentelemetry_api = "^0.20.0"

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -194,7 +194,7 @@ fn init_tracing(serve_command: &ServeCommand) -> Result<(), Box<dyn Error>> {
                 ]))
                 .with_sampler(Sampler::ParentBased(Box::new(Sampler::AlwaysOn))),
         )
-        .install_batch(opentelemetry::runtime::Tokio)?;
+        .install_batch(opentelemetry::runtime::TokioCurrentThread)?;
 
     tracing_subscriber::registry()
         .with(


### PR DESCRIPTION
Losing loads of traces when load testing `postgres-ndc`, trying this.