### PR TITLE
Add a health check for the configuration server that always passes.

### DIFF
--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -494,6 +494,7 @@ where
         .route("/", get(get_empty::<C>).post(post_update::<C>))
         .route("/schema", get(get_config_schema::<C>))
         .route("/validate", post(post_validate::<C>))
+        .route("/health", get(|| async {}))
         .layer(cors);
 
     axum::Server::bind(&address)


### PR DESCRIPTION
This allows us to use the `check-health` command for the configuration server too.