### PR TITLE
make service_token_schema key not required

### DIFF
--- a/rust-connector-sdk/src/default_main/v2_compat.rs
+++ b/rust-connector-sdk/src/default_main/v2_compat.rs
@@ -157,7 +157,7 @@ fn get_openapi_config_schema_response() -> ConfigSchemaResponse {
                 "type": "string"
             }
         },
-        "required": ["service_token_secret"]
+        "required": []
     });
 
     ConfigSchemaResponse {


### PR DESCRIPTION
Update config schema for v2 compatibility mode to make `service_token_secret` optional.

Was previously nullable, (still is), but aparenlty the UI does not care.

This does still cause UI issues when `service_token_secret` is absent but those should be fixed eventually? 