### PR TITLE
remove `get_x_region`

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -287,12 +287,15 @@ pub trait Connector {
     ) -> Result<models::QueryResponse, QueryError>;
 }
 
+#[derive(Serialize)]
 pub enum ConnectorMode {
     ReadOnly,
     ReadWrite,
     WriteOnly,
 }
 
+#[derive(Serialize)]
+#[serde(bound = "<C as Connector>::Configuration: Serialize")]
 pub struct RegionConfiguration<C: Connector + ?Sized> {
     pub config: <C as Connector>::Configuration,
     pub mode: ConnectorMode,

--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use ndc_client::models;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{collections::HashMap, error::Error};
+use serde::Serialize;
+use std::error::Error;
 use thiserror::Error;
 pub mod example;
 
@@ -189,14 +189,6 @@ pub trait Connector {
     /// The type of unserializable state
     type State;
 
-    /// Creates the region configuration map
-    async fn make_region_configuration_map(
-        _raw_config: &Self::RawConfiguration,
-    ) -> Result<HashMap<String, RegionConfiguration<Self>>, ValidateError> {
-        // Defaults to an empty map
-        Ok(HashMap::new())
-    }
-
     fn make_empty_configuration() -> Self::RawConfiguration;
 
     async fn update_configuration(
@@ -285,18 +277,4 @@ pub trait Connector {
         state: &Self::State,
         request: models::QueryRequest,
     ) -> Result<models::QueryResponse, QueryError>;
-}
-
-#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
-pub enum ConnectorMode {
-    ReadOnly,
-    ReadWrite,
-    WriteOnly,
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(bound = "C::Configuration: Serialize, C::Configuration: DeserializeOwned")]
-pub struct RegionConfiguration<C: Connector + ?Sized> {
-    pub config: C::Configuration,
-    pub mode: ConnectorMode,
 }

--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use ndc_client::models;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, error::Error};
 use thiserror::Error;
 pub mod example;
@@ -287,15 +287,17 @@ pub trait Connector {
     ) -> Result<models::QueryResponse, QueryError>;
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub enum ConnectorMode {
     ReadOnly,
     ReadWrite,
     WriteOnly,
 }
 
-#[derive(Serialize)]
-#[serde(bound = "<C as Connector>::Configuration: Serialize")]
+#[derive(Serialize, Deserialize)]
+#[serde(
+    bound = "<C as Connector>::Configuration: Serialize, <C as Connector>::Configuration: DeserializeOwned"
+)]
 pub struct RegionConfiguration<C: Connector + ?Sized> {
     pub config: <C as Connector>::Configuration,
     pub mode: ConnectorMode,

--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -287,7 +287,7 @@ pub trait Connector {
     ) -> Result<models::QueryResponse, QueryError>;
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub enum ConnectorMode {
     ReadOnly,
     ReadWrite,

--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -190,11 +190,11 @@ pub trait Connector {
     type State;
 
     /// Creates the region configuration map
-    fn make_region_configuration_map(
+    async fn make_region_configuration_map(
         _raw_config: &Self::RawConfiguration,
-    ) -> HashMap<String, RegionConfiguration<Self>> {
+    ) -> Result<HashMap<String, RegionConfiguration<Self>>, ValidateError> {
         // Defaults to an empty map
-        HashMap::new()
+        Ok(HashMap::new())
     }
 
     fn make_empty_configuration() -> Self::RawConfiguration;
@@ -295,10 +295,8 @@ pub enum ConnectorMode {
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(
-    bound = "<C as Connector>::Configuration: Serialize, <C as Connector>::Configuration: DeserializeOwned"
-)]
+#[serde(bound = "C::Configuration: Serialize, C::Configuration: DeserializeOwned")]
 pub struct RegionConfiguration<C: Connector + ?Sized> {
-    pub config: <C as Connector>::Configuration,
+    pub config: C::Configuration,
     pub mode: ConnectorMode,
 }

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -17,14 +17,6 @@ impl Connector for Example {
 
     fn make_empty_configuration() -> Self::RawConfiguration {}
 
-    fn get_read_regions(_config: &Self::Configuration) -> Vec<String> {
-        Vec::new()
-    }
-
-    fn get_write_regions(_config: &Self::Configuration) -> Vec<String> {
-        Vec::new()
-    }
-
     async fn update_configuration(
         _config: &Self::RawConfiguration,
     ) -> Result<Self::RawConfiguration, UpdateConfigurationError> {


### PR DESCRIPTION
This PR removes the `get_x_region` methods from the `Connector` trait.