### PR TITLE
point to v3 connectors instead of v2 connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ This allows Hasura users to instantly get a powerful Hasura GraphQL API (paginat
 
 ## Registry
 
-There are 2 connectors you can start trying out today, and we'll gradually add more to this list:
+There are 3 connectors you can start trying out today, and we'll gradually add more to this list:
 
 1. [hasura/ndc-clickhouse](https://github.com/hasura/ndc-clickhouse)
 2. [hasura/ndc-qdrant](https://github.com/hasura/ndc-qdrant)
+3. [hasura/ndc-sendgrid](https://github.com/hasura/ndc-sendgrid/)
 
 ## SDK & Guides
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ This allows Hasura users to instantly get a powerful Hasura GraphQL API (paginat
 
 ## Registry
 
-There are 3 connectors you can start trying out today, and we'll gradually add more to this list:
+There are 4 connectors you can start trying out today, and we'll gradually add more to this list:
 
 1. [hasura/ndc-clickhouse](https://github.com/hasura/ndc-clickhouse)
 2. [hasura/ndc-qdrant](https://github.com/hasura/ndc-qdrant)
 3. [hasura/ndc-sendgrid](https://github.com/hasura/ndc-sendgrid/)
+4. [hasura/ndc-typescript-deno](https://github.com/hasura/ndc-typescript-deno)
 
 ## SDK & Guides
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Hasura Native Data Connector Hub: ndc-hub
 
 This repository provides:
-1. A registry of connectors and 
-2. Resources to help build connectors to connect new & custom data sources to Hasura. 
+
+1. A registry of connectors and
+2. Resources to help build connectors to connect new & custom data sources to Hasura.
 
 This allows Hasura users to instantly get a powerful Hasura GraphQL API (pagination, filtering, sorting, relationships) with granular RLS style authorization out of the box on any data-source (DBs, APIs).
 
@@ -12,8 +13,9 @@ This allows Hasura users to instantly get a powerful Hasura GraphQL API (paginat
 ## Registry
 
 There are 2 connectors you can start trying out today, and we'll gradually add more to this list:
-1. [hasura/clickhouse](https://github.com/hasura/clickhouse_gdc_v2)
-2. [hasura/weaviate](https://github.com/hasura/weaviate_gdc)
+
+1. [hasura/ndc-clickhouse](https://github.com/hasura/ndc-clickhouse)
+2. [hasura/ndc-qdrant](https://github.com/hasura/ndc-qdrant)
 
 ## SDK & Guides
 
@@ -59,15 +61,14 @@ The serve command emits OTLP trace information. This can be used to see details 
 
 To enable tracing you must:
 
-* Use the NDC-Hub option `--otlp-endpoint` e.g. `http://localhost:4317`
-* Or, set the NDC-Hub ENV Variable `OTLP_ENDPOINT`
-* Or, set the `tracing` ENV Variable `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+- Use the NDC-Hub option `--otlp-endpoint` e.g. `http://localhost:4317`
+- Or, set the NDC-Hub ENV Variable `OTLP_ENDPOINT`
+- Or, set the `tracing` ENV Variable `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 
 For additional service information you can:
 
-* Set `OTEL_SERVICE_NAME` e.g. `ndc_hub_example`
-* Set `OTEL_RESOURCE_ATTRIBUTES` e.g. `key=value, k = v , a= x, a=z`
-
+- Set `OTEL_SERVICE_NAME` e.g. `ndc_hub_example`
+- Set `OTEL_RESOURCE_ATTRIBUTES` e.g. `key=value, k = v , a= x, a=z`
 
 To view trace information during local development you can run a Jager server via Docker:
 


### PR DESCRIPTION
The readme links to v2 connectors, which can be missleading.

This PR changes these links to point to public v3 connectors instead.

The postgres connector is not public (yet?) so we don't point to it for now.