### PR TITLE
chore: enable tracing in config server

### DIFF
--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -174,6 +174,11 @@ where
     let router = create_router::<C>(
         server_state.clone(),
         serve_command.service_token_secret.clone(),
+    )
+    .layer(
+        TraceLayer::new_for_http()
+            .make_span_with(make_span)
+            .on_response(on_response),
     );
 
     let router = if serve_command.enable_v2_compatibility {

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -88,6 +88,10 @@ enum ConfigurationSubcommand {
 struct ServeConfigurationCommand {
     #[arg(long, value_name = "PORT", env = "PORT", default_value = "9100")]
     port: Port,
+    #[arg(long, value_name = "OTEL_SERVICE_NAME", env = "OTEL_SERVICE_NAME")]
+    service_name: Option<String>,
+    #[arg(long, value_name = "OTLP_ENDPOINT", env = "OTLP_ENDPOINT")]
+    otlp_endpoint: Option<String>, // NOTE: `tracing` crate uses `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` ENV variable, but we want to control the endpoint via CLI interface
 }
 
 #[derive(Clone, Parser)]
@@ -427,6 +431,9 @@ where
 {
     let port = serve_command.port;
     let address = net::SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::UNSPECIFIED), port);
+
+    init_tracing(&serve_command.service_name, &serve_command.otlp_endpoint)
+        .expect("Unable to initialize tracing");
 
     println!("Starting server on {}", address);
 

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -174,11 +174,6 @@ where
     let router = create_router::<C>(
         server_state.clone(),
         serve_command.service_token_secret.clone(),
-    )
-    .layer(
-        TraceLayer::new_for_http()
-            .make_span_with(make_span)
-            .on_response(on_response),
     );
 
     let router = if serve_command.enable_v2_compatibility {
@@ -451,6 +446,11 @@ where
         .route("/schema", get(get_config_schema::<C>))
         .route("/validate", post(post_validate::<C>))
         .route("/health", get(|| async {}))
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(make_span)
+                .on_response(on_response),
+        )
         .layer(cors);
 
     axum::Server::bind(&address)


### PR DESCRIPTION
This adds `service_name` and `otlp_endpoint` to the serve configuration command, so that we can emit traces when running as a config server.