### PR TITLE
Move configuration when we don't need to hold onto it.

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -192,13 +192,13 @@ pub trait Connector {
     fn make_empty_configuration() -> Self::RawConfiguration;
 
     async fn update_configuration(
-        config: &Self::RawConfiguration,
+        config: Self::RawConfiguration,
     ) -> Result<Self::RawConfiguration, UpdateConfigurationError>;
 
     /// Validate the raw configuration provided by the user,
     /// returning a configuration error or a validated [`Connector::Configuration`].
     async fn validate_raw_configuration(
-        configuration: &Self::RawConfiguration,
+        configuration: Self::RawConfiguration,
     ) -> Result<Self::Configuration, ValidateError>;
 
     /// Initialize the connector's in-memory state.

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -18,13 +18,13 @@ impl Connector for Example {
     fn make_empty_configuration() -> Self::RawConfiguration {}
 
     async fn update_configuration(
-        _config: &Self::RawConfiguration,
+        _config: Self::RawConfiguration,
     ) -> Result<Self::RawConfiguration, UpdateConfigurationError> {
         Ok(())
     }
 
     async fn validate_raw_configuration(
-        _configuration: &Self::Configuration,
+        _configuration: Self::Configuration,
     ) -> Result<Self::Configuration, ValidateError> {
         Ok(())
     }

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -235,7 +235,7 @@ where
     let configuration_json = std::fs::read_to_string(config_file).unwrap();
     let raw_configuration =
         serde_json::de::from_str::<C::RawConfiguration>(configuration_json.as_str()).unwrap();
-    let configuration = C::validate_raw_configuration(&raw_configuration)
+    let configuration = C::validate_raw_configuration(raw_configuration)
         .await
         .unwrap();
 
@@ -478,7 +478,7 @@ async fn post_update<C: Connector>(
 where
     C::RawConfiguration: Serialize + DeserializeOwned,
 {
-    let updated = C::update_configuration(&configuration)
+    let updated = C::update_configuration(configuration)
         .await
         .map_err(|err| match err {
             UpdateConfigurationError::Other(err) => {
@@ -514,14 +514,15 @@ async fn post_validate<C: Connector>(
 where
     C::RawConfiguration: DeserializeOwned,
 {
-    let configuration = C::validate_raw_configuration(&configuration)
-        .await
-        .map_err(|e| match e {
-            crate::connector::ValidateError::ValidateError(ranges) => (
-                StatusCode::BAD_REQUEST,
-                Json(ValidateErrors::InvalidConfiguration { ranges }),
-            ),
-        })?;
+    let configuration =
+        C::validate_raw_configuration(configuration)
+            .await
+            .map_err(|e| match e {
+                crate::connector::ValidateError::ValidateError(ranges) => (
+                    StatusCode::BAD_REQUEST,
+                    Json(ValidateErrors::InvalidConfiguration { ranges }),
+                ),
+            })?;
     let schema = C::get_schema(&configuration).await.map_err(|e| match e {
         SchemaError::Other(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -577,7 +578,7 @@ where
     let configuration_json = std::fs::read_to_string(command.configuration).unwrap();
     let raw_configuration =
         serde_json::de::from_str::<C::RawConfiguration>(configuration_json.as_str()).unwrap();
-    let configuration = C::validate_raw_configuration(&raw_configuration)
+    let configuration = C::validate_raw_configuration(raw_configuration)
         .await
         .unwrap();
 

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -144,7 +144,7 @@ pub struct ServerState<C: Connector> {
 /// - Logs are written to stdout
 pub async fn default_main<C: Connector + Clone + Default + 'static>() -> Result<(), Box<dyn Error>>
 where
-    C::RawConfiguration: Serialize + DeserializeOwned + JsonSchema + Sync + Send + Clone,
+    C::RawConfiguration: Serialize + DeserializeOwned + JsonSchema + Sync + Send,
     C::Configuration: Serialize + DeserializeOwned + Sync + Send + Clone,
     C::State: Sync + Send + Clone,
 {
@@ -412,7 +412,7 @@ async fn configuration<C: Connector + 'static>(
     command: ConfigurationCommand,
 ) -> Result<(), Box<dyn Error>>
 where
-    C::RawConfiguration: Serialize + DeserializeOwned + JsonSchema + Clone + Sync + Send,
+    C::RawConfiguration: Serialize + DeserializeOwned + JsonSchema + Sync + Send,
     C::Configuration: Sync + Send,
 {
     match command.command {


### PR DESCRIPTION
There are certain functions in the `Connector` trait that use the raw configuration, and accept a reference. We don't actually need to keep the configuration around in the SDK so we can pass by value here, which means that the relevant functions can own the data if they require it.

Making these input parameters values rather than references allows us to avoid cloning in other locations later.