### PR TITLE
Introduce a "fast path" for returning already-serialized JSON.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-test-helper"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298f62fa902c2515c169ab0bfb56c593229f33faa01131215d58e3d4898e3aa9"
+dependencies = [
+ "axum",
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "reqwest",
+ "serde",
+ "tokio",
+ "tower",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,11 +1026,14 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-macros",
+ "axum-test-helper",
  "base64 0.21.4",
+ "bytes",
  "clap",
  "gdc_rust_types",
  "http",
  "indexmap 1.9.3",
+ "mime",
  "ndc-client",
  "ndc-test",
  "opentelemetry",
@@ -1556,10 +1577,12 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -2432,6 +2455,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -53,3 +53,8 @@ url = "2.4.1"
 uuid = "^1.3.4"
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types", rev = "bc57c40" }
 indexmap = "^1"
+bytes = "1.5.0"
+mime = "0.3.17"
+
+[dev-dependencies]
+axum-test-helper = "0.3.0"

--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -3,6 +3,9 @@ use ndc_client::models;
 use serde::Serialize;
 use std::error::Error;
 use thiserror::Error;
+
+use crate::json_response::JsonResponse;
+
 pub mod example;
 
 /// Errors which occur when trying to validate connector
@@ -35,7 +38,7 @@ pub enum KeyOrIndex {
 #[derive(Debug, Error)]
 pub enum UpdateConfigurationError {
     #[error("error validating configuration: {0}")]
-    Other(Box<dyn Error + Send + Sync>),
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Errors which occur when trying to initialize connector
@@ -45,7 +48,7 @@ pub enum UpdateConfigurationError {
 #[derive(Debug, Error)]
 pub enum InitializationError {
     #[error("error initializing connector state: {0}")]
-    Other(Box<dyn Error + Send + Sync>),
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Errors which occur when trying to update metrics.
@@ -54,7 +57,7 @@ pub enum InitializationError {
 #[derive(Debug, Error)]
 pub enum FetchMetricsError {
     #[error("error fetching metrics: {0}")]
-    Other(Box<dyn Error + Send + Sync>),
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Errors which occur when checking connector health.
@@ -63,7 +66,7 @@ pub enum FetchMetricsError {
 #[derive(Debug, Error)]
 pub enum HealthError {
     #[error("error checking health status: {0}")]
-    Other(Box<dyn Error + Send + Sync>),
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Errors which occur when retrieving the connector schema.
@@ -72,7 +75,7 @@ pub enum HealthError {
 #[derive(Debug, Error)]
 pub enum SchemaError {
     #[error("error retrieving the schema: {0}")]
-    Other(Box<dyn Error + Send + Sync>),
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Errors which occur when executing a query.
@@ -91,7 +94,7 @@ pub enum QueryError {
     #[error("unsupported operation: {0}")]
     UnsupportedOperation(String),
     #[error("error executing query: {0}")]
-    Other(Box<dyn Error + Send + Sync>),
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Errors which occur when explaining a query.
@@ -110,7 +113,7 @@ pub enum ExplainError {
     #[error("unsupported operation: {0}")]
     UnsupportedOperation(String),
     #[error("error explaining query: {0}")]
-    Other(Box<dyn Error + Send + Sync>),
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Errors which occur when executing a mutation.
@@ -137,7 +140,7 @@ pub enum MutationError {
     #[error("mutation violates constraint: {0}")]
     ConstraintNotMet(String),
     #[error("error executing mutation: {0}")]
-    Other(Box<dyn Error + Send + Sync>),
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Connectors using this library should implement this trait.
@@ -238,7 +241,7 @@ pub trait Connector {
     ///
     /// This function implements the [capabilities endpoint](https://hasura.github.io/ndc-spec/specification/capabilities.html)
     /// from the NDC specification.
-    async fn get_capabilities() -> models::CapabilitiesResponse;
+    async fn get_capabilities() -> JsonResponse<models::CapabilitiesResponse>;
 
     /// Get the connector's schema.
     ///
@@ -246,7 +249,7 @@ pub trait Connector {
     /// from the NDC specification.
     async fn get_schema(
         configuration: &Self::Configuration,
-    ) -> Result<models::SchemaResponse, SchemaError>;
+    ) -> Result<JsonResponse<models::SchemaResponse>, SchemaError>;
 
     /// Explain a query by creating an execution plan
     ///
@@ -256,7 +259,7 @@ pub trait Connector {
         configuration: &Self::Configuration,
         state: &Self::State,
         request: models::QueryRequest,
-    ) -> Result<models::ExplainResponse, ExplainError>;
+    ) -> Result<JsonResponse<models::ExplainResponse>, ExplainError>;
 
     /// Execute a mutation
     ///
@@ -266,7 +269,7 @@ pub trait Connector {
         configuration: &Self::Configuration,
         state: &Self::State,
         request: models::MutationRequest,
-    ) -> Result<models::MutationResponse, MutationError>;
+    ) -> Result<JsonResponse<models::MutationResponse>, MutationError>;
 
     /// Execute a query
     ///
@@ -276,5 +279,5 @@ pub trait Connector {
         configuration: &Self::Configuration,
         state: &Self::State,
         request: models::QueryRequest,
-    ) -> Result<models::QueryResponse, QueryError>;
+    ) -> Result<JsonResponse<models::QueryResponse>, QueryError>;
 }

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -50,8 +50,8 @@ impl Connector for Example {
         Ok(())
     }
 
-    async fn get_capabilities() -> models::CapabilitiesResponse {
-        models::CapabilitiesResponse {
+    async fn get_capabilities() -> JsonResponse<models::CapabilitiesResponse> {
+        JsonResponse::Value(models::CapabilitiesResponse {
             versions: "^0.1.0".into(),
             capabilities: models::Capabilities {
                 explain: None,
@@ -63,32 +63,32 @@ impl Connector for Example {
                     relation_comparisons: None,
                 }),
             },
-        }
+        })
     }
 
     async fn get_schema(
         _configuration: &Self::Configuration,
-    ) -> Result<models::SchemaResponse, SchemaError> {
+    ) -> Result<JsonResponse<models::SchemaResponse>, SchemaError> {
         async {
             info_span!("inside tracing example");
         }
         .instrument(info_span!("tracing example"))
         .await;
 
-        Ok(models::SchemaResponse {
+        Ok(JsonResponse::Value(models::SchemaResponse {
             collections: vec![],
             functions: vec![],
             procedures: vec![],
             object_types: BTreeMap::new(),
             scalar_types: BTreeMap::new(),
-        })
+        }))
     }
 
     async fn explain(
         _configuration: &Self::Configuration,
         _state: &Self::State,
         _request: models::QueryRequest,
-    ) -> Result<models::ExplainResponse, ExplainError> {
+    ) -> Result<JsonResponse<models::ExplainResponse>, ExplainError> {
         todo!()
     }
 
@@ -96,7 +96,7 @@ impl Connector for Example {
         _configuration: &Self::Configuration,
         _state: &Self::State,
         _request: models::MutationRequest,
-    ) -> Result<models::MutationResponse, MutationError> {
+    ) -> Result<JsonResponse<models::MutationResponse>, MutationError> {
         todo!()
     }
 
@@ -104,7 +104,7 @@ impl Connector for Example {
         _configuration: &Self::Configuration,
         _state: &Self::State,
         _request: models::QueryRequest,
-    ) -> Result<models::QueryResponse, QueryError> {
+    ) -> Result<JsonResponse<models::QueryResponse>, QueryError> {
         todo!()
     }
 }

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -51,7 +51,7 @@ impl Connector for Example {
     }
 
     async fn get_capabilities() -> JsonResponse<models::CapabilitiesResponse> {
-        JsonResponse::Value(models::CapabilitiesResponse {
+        models::CapabilitiesResponse {
             versions: "^0.1.0".into(),
             capabilities: models::Capabilities {
                 explain: None,
@@ -63,7 +63,8 @@ impl Connector for Example {
                     relation_comparisons: None,
                 }),
             },
-        })
+        }
+        .into()
     }
 
     async fn get_schema(
@@ -75,13 +76,14 @@ impl Connector for Example {
         .instrument(info_span!("tracing example"))
         .await;
 
-        Ok(JsonResponse::Value(models::SchemaResponse {
+        Ok(models::SchemaResponse {
             collections: vec![],
             functions: vec![],
             procedures: vec![],
             object_types: BTreeMap::new(),
             scalar_types: BTreeMap::new(),
-        }))
+        }
+        .into())
     }
 
     async fn explain(

--- a/rust-connector-sdk/src/json_response.rs
+++ b/rust-connector-sdk/src/json_response.rs
@@ -1,0 +1,116 @@
+use axum::response::IntoResponse;
+use bytes::Bytes;
+use http::{header, HeaderValue};
+
+/// Represents a response value that will be serialized to JSON.
+///
+/// The value may be of a type that implements `serde::Serialize`, or it may be
+/// a contiguous sequence of bytes, which are _assumed_ to be valid JSON.
+#[derive(Debug, Clone)]
+pub enum JsonResponse<A: serde::Serialize + (for<'de> serde::Deserialize<'de>)> {
+    /// A value that can be serialized to JSON.
+    Value(A),
+    /// A serialized JSON bytestring that is assumed to represent a value of
+    /// type `A`. This is not guaranteed by the SDK; the connector is
+    /// responsible for ensuring this.
+    Serialized(Bytes),
+}
+
+impl<A: serde::Serialize + (for<'de> serde::Deserialize<'de>)> JsonResponse<A> {
+    /// Unwraps the value, deserializing if necessary.
+    ///
+    /// This is only intended for testing and compatibility. If it lives on a
+    /// critical path, we recommend you avoid it.
+    pub(crate) fn into_value<E: From<Box<dyn std::error::Error + Send + Sync>>>(
+        self,
+    ) -> Result<A, E> {
+        match self {
+            JsonResponse::Value(value) => Ok(value),
+            JsonResponse::Serialized(bytes) => {
+                serde_json::de::from_slice(&bytes).map_err(|err| E::from(Box::new(err)))
+            }
+        }
+    }
+}
+
+impl<A: serde::Serialize + (for<'de> serde::Deserialize<'de>)> IntoResponse for JsonResponse<A> {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            JsonResponse::Value(value) => axum::Json(value).into_response(),
+            JsonResponse::Serialized(bytes) => (
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::APPLICATION_JSON.as_ref()),
+                )],
+                bytes,
+            )
+                .into_response(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{routing, Router};
+    use axum_test_helper::TestClient;
+    use reqwest::StatusCode;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn serializes_value_to_json() {
+        let app = Router::new().route(
+            "/",
+            routing::get(|| async {
+                JsonResponse::Value(Person {
+                    name: "Alice Appleton".to_owned(),
+                    age: 42,
+                })
+            }),
+        );
+
+        let client = TestClient::new(app);
+        let response = client.get("/").send().await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let headers = response.headers();
+        assert_eq!(
+            headers.get_all("Content-Type").iter().collect::<Vec<_>>(),
+            vec!["application/json"]
+        );
+
+        let body = response.text().await;
+        assert_eq!(body, r#"{"name":"Alice Appleton","age":42}"#);
+    }
+
+    #[tokio::test]
+    async fn writes_json_string_directly() {
+        let app = Router::new().route(
+            "/",
+            routing::get(|| async {
+                JsonResponse::Serialized::<Person>(r#"{"name":"Bob Davis","age":7}"#.into())
+            }),
+        );
+
+        let client = TestClient::new(app);
+        let response = client.get("/").send().await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let headers = response.headers();
+        assert_eq!(
+            headers.get_all("Content-Type").iter().collect::<Vec<_>>(),
+            vec!["application/json"]
+        );
+
+        let body = response.text().await;
+        assert_eq!(body, r#"{"name":"Bob Davis","age":7}"#);
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct Person {
+        name: String,
+        age: u16,
+    }
+}

--- a/rust-connector-sdk/src/json_response.rs
+++ b/rust-connector-sdk/src/json_response.rs
@@ -7,7 +7,7 @@ use http::{header, HeaderValue};
 /// The value may be of a type that implements `serde::Serialize`, or it may be
 /// a contiguous sequence of bytes, which are _assumed_ to be valid JSON.
 #[derive(Debug, Clone)]
-pub enum JsonResponse<A: serde::Serialize + (for<'de> serde::Deserialize<'de>)> {
+pub enum JsonResponse<A> {
     /// A value that can be serialized to JSON.
     Value(A),
     /// A serialized JSON bytestring that is assumed to represent a value of
@@ -16,7 +16,7 @@ pub enum JsonResponse<A: serde::Serialize + (for<'de> serde::Deserialize<'de>)> 
     Serialized(Bytes),
 }
 
-impl<A: serde::Serialize + (for<'de> serde::Deserialize<'de>)> JsonResponse<A> {
+impl<A: (for<'de> serde::Deserialize<'de>)> JsonResponse<A> {
     /// Unwraps the value, deserializing if necessary.
     ///
     /// This is only intended for testing and compatibility. If it lives on a
@@ -33,7 +33,7 @@ impl<A: serde::Serialize + (for<'de> serde::Deserialize<'de>)> JsonResponse<A> {
     }
 }
 
-impl<A: serde::Serialize + (for<'de> serde::Deserialize<'de>)> IntoResponse for JsonResponse<A> {
+impl<A: serde::Serialize> IntoResponse for JsonResponse<A> {
     fn into_response(self) -> axum::response::Response {
         match self {
             JsonResponse::Value(value) => axum::Json(value).into_response(),

--- a/rust-connector-sdk/src/lib.rs
+++ b/rust-connector-sdk/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod check_health;
 pub mod connector;
 pub mod default_main;
+pub mod json_response;
 pub mod routes;
 pub mod tracing;
 

--- a/rust-connector-sdk/src/routes.rs
+++ b/rust-connector-sdk/src/routes.rs
@@ -2,7 +2,10 @@ use axum::{http::StatusCode, Json};
 use ndc_client::models;
 use prometheus::{Registry, TextEncoder};
 
-use crate::connector::{Connector, HealthError};
+use crate::{
+    connector::{Connector, HealthError},
+    json_response::JsonResponse,
+};
 
 pub fn get_metrics<C: Connector>(
     configuration: &C::Configuration,
@@ -35,8 +38,8 @@ pub fn get_metrics<C: Connector>(
     })
 }
 
-pub async fn get_capabilities<C: Connector>() -> Json<models::CapabilitiesResponse> {
-    Json(C::get_capabilities().await)
+pub async fn get_capabilities<C: Connector>() -> JsonResponse<models::CapabilitiesResponse> {
+    C::get_capabilities().await
 }
 
 pub async fn get_health<C: Connector>(
@@ -58,10 +61,30 @@ pub async fn get_health<C: Connector>(
 
 pub async fn get_schema<C: Connector>(
     configuration: &C::Configuration,
-) -> Result<Json<models::SchemaResponse>, (StatusCode, Json<models::ErrorResponse>)> {
-    Ok(Json(C::get_schema(configuration).await.map_err(
-        |e| match e {
-            crate::connector::SchemaError::Other(err) => (
+) -> Result<JsonResponse<models::SchemaResponse>, (StatusCode, Json<models::ErrorResponse>)> {
+    C::get_schema(configuration).await.map_err(|e| match e {
+        crate::connector::SchemaError::Other(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(models::ErrorResponse {
+                message: "Internal error".into(),
+                details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                    "cause".into(),
+                    serde_json::Value::String(err.to_string()),
+                )])),
+            }),
+        ),
+    })
+}
+
+pub async fn post_explain<C: Connector>(
+    configuration: &C::Configuration,
+    state: &C::State,
+    Json(request): Json<models::QueryRequest>,
+) -> Result<JsonResponse<models::ExplainResponse>, (StatusCode, Json<models::ErrorResponse>)> {
+    C::explain(configuration, state, request)
+        .await
+        .map_err(|e| match e {
+            crate::connector::ExplainError::Other(err) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(models::ErrorResponse {
                     message: "Internal error".into(),
@@ -71,155 +94,127 @@ pub async fn get_schema<C: Connector>(
                     )])),
                 }),
             ),
-        },
-    )?))
-}
-
-pub async fn post_explain<C: Connector>(
-    configuration: &C::Configuration,
-    state: &C::State,
-    Json(request): Json<models::QueryRequest>,
-) -> Result<Json<models::ExplainResponse>, (StatusCode, Json<models::ErrorResponse>)> {
-    Ok(Json(
-        C::explain(configuration, state, request)
-            .await
-            .map_err(|e| match e {
-                crate::connector::ExplainError::Other(err) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(models::ErrorResponse {
-                        message: "Internal error".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "cause".into(),
-                            serde_json::Value::String(err.to_string()),
-                        )])),
-                    }),
-                ),
-                crate::connector::ExplainError::InvalidRequest(detail) => (
-                    StatusCode::BAD_REQUEST,
-                    Json(models::ErrorResponse {
-                        message: "Invalid request".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "detail".into(),
-                            serde_json::Value::String(detail),
-                        )])),
-                    }),
-                ),
-                crate::connector::ExplainError::UnsupportedOperation(detail) => (
-                    StatusCode::NOT_IMPLEMENTED,
-                    Json(models::ErrorResponse {
-                        message: "Unsupported operation".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "detail".into(),
-                            serde_json::Value::String(detail),
-                        )])),
-                    }),
-                ),
-            })?,
-    ))
+            crate::connector::ExplainError::InvalidRequest(detail) => (
+                StatusCode::BAD_REQUEST,
+                Json(models::ErrorResponse {
+                    message: "Invalid request".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+            crate::connector::ExplainError::UnsupportedOperation(detail) => (
+                StatusCode::NOT_IMPLEMENTED,
+                Json(models::ErrorResponse {
+                    message: "Unsupported operation".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+        })
 }
 
 pub async fn post_mutation<C: Connector>(
     configuration: &C::Configuration,
     state: &C::State,
     Json(request): Json<models::MutationRequest>,
-) -> Result<Json<models::MutationResponse>, (StatusCode, Json<models::ErrorResponse>)> {
-    Ok(Json(
-        C::mutation(configuration, state, request)
-            .await
-            .map_err(|e| match e {
-                crate::connector::MutationError::Other(err) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(models::ErrorResponse {
-                        message: "Internal error".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "cause".into(),
-                            serde_json::Value::String(err.to_string()),
-                        )])),
-                    }),
-                ),
-                crate::connector::MutationError::InvalidRequest(detail) => (
-                    StatusCode::BAD_REQUEST,
-                    Json(models::ErrorResponse {
-                        message: "Invalid request".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "detail".into(),
-                            serde_json::Value::String(detail),
-                        )])),
-                    }),
-                ),
-                crate::connector::MutationError::UnsupportedOperation(detail) => (
-                    StatusCode::NOT_IMPLEMENTED,
-                    Json(models::ErrorResponse {
-                        message: "Unsupported operation".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "detail".into(),
-                            serde_json::Value::String(detail),
-                        )])),
-                    }),
-                ),
-                crate::connector::MutationError::Conflict(detail) => (
-                    StatusCode::CONFLICT,
-                    Json(models::ErrorResponse {
-                        message: "Request would create a conflicting state".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "detail".into(),
-                            serde_json::Value::String(detail),
-                        )])),
-                    }),
-                ),
-                crate::connector::MutationError::ConstraintNotMet(detail) => (
-                    StatusCode::FORBIDDEN,
-                    Json(models::ErrorResponse {
-                        message: "Constraint not met".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "detail".into(),
-                            serde_json::Value::String(detail),
-                        )])),
-                    }),
-                ),
-            })?,
-    ))
+) -> Result<JsonResponse<models::MutationResponse>, (StatusCode, Json<models::ErrorResponse>)> {
+    C::mutation(configuration, state, request)
+        .await
+        .map_err(|e| match e {
+            crate::connector::MutationError::Other(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(models::ErrorResponse {
+                    message: "Internal error".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "cause".into(),
+                        serde_json::Value::String(err.to_string()),
+                    )])),
+                }),
+            ),
+            crate::connector::MutationError::InvalidRequest(detail) => (
+                StatusCode::BAD_REQUEST,
+                Json(models::ErrorResponse {
+                    message: "Invalid request".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+            crate::connector::MutationError::UnsupportedOperation(detail) => (
+                StatusCode::NOT_IMPLEMENTED,
+                Json(models::ErrorResponse {
+                    message: "Unsupported operation".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+            crate::connector::MutationError::Conflict(detail) => (
+                StatusCode::CONFLICT,
+                Json(models::ErrorResponse {
+                    message: "Request would create a conflicting state".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+            crate::connector::MutationError::ConstraintNotMet(detail) => (
+                StatusCode::FORBIDDEN,
+                Json(models::ErrorResponse {
+                    message: "Constraint not met".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+        })
 }
 
 pub async fn post_query<C: Connector>(
     configuration: &C::Configuration,
     state: &C::State,
     Json(request): Json<models::QueryRequest>,
-) -> Result<Json<models::QueryResponse>, (StatusCode, Json<models::ErrorResponse>)> {
-    Ok(Json(
-        C::query(configuration, state, request)
-            .await
-            .map_err(|e| match e {
-                crate::connector::QueryError::Other(err) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(models::ErrorResponse {
-                        message: "Internal error".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "cause".into(),
-                            serde_json::Value::String(err.to_string()),
-                        )])),
-                    }),
-                ),
-                crate::connector::QueryError::InvalidRequest(detail) => (
-                    StatusCode::BAD_REQUEST,
-                    Json(models::ErrorResponse {
-                        message: "Invalid request".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "detail".into(),
-                            serde_json::Value::String(detail),
-                        )])),
-                    }),
-                ),
-                crate::connector::QueryError::UnsupportedOperation(detail) => (
-                    StatusCode::NOT_IMPLEMENTED,
-                    Json(models::ErrorResponse {
-                        message: "Unsupported operation".into(),
-                        details: serde_json::Value::Object(serde_json::Map::from_iter([(
-                            "detail".into(),
-                            serde_json::Value::String(detail),
-                        )])),
-                    }),
-                ),
-            })?,
-    ))
+) -> Result<JsonResponse<models::QueryResponse>, (StatusCode, Json<models::ErrorResponse>)> {
+    C::query(configuration, state, request)
+        .await
+        .map_err(|e| match e {
+            crate::connector::QueryError::Other(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(models::ErrorResponse {
+                    message: "Internal error".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "cause".into(),
+                        serde_json::Value::String(err.to_string()),
+                    )])),
+                }),
+            ),
+            crate::connector::QueryError::InvalidRequest(detail) => (
+                StatusCode::BAD_REQUEST,
+                Json(models::ErrorResponse {
+                    message: "Invalid request".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+            crate::connector::QueryError::UnsupportedOperation(detail) => (
+                StatusCode::NOT_IMPLEMENTED,
+                Json(models::ErrorResponse {
+                    message: "Unsupported operation".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+        })
 }


### PR DESCRIPTION
This introduces a new enum, `JsonResponse`, which is designed to supplant `axum::Json`. It implements `axum::IntoResponse`.

It has two variants:

1. `Value`, which behaves the same as `axum::Json`.
2. `Serialized`, which allows the connector to provide already-serialized JSON in the form of a `Bytes` value.

The latter can be used to construct the JSON directly in the database and avoid deserialization and re-serialization.

This is a breaking change, as at the very least, the connector implementations will now need to wrap responses in `JsonResponse::Value`. Hopefully it's not too much of a big deal.

There is a helper function, `JsonResponse::into_value`, used to deserialize the serialized bytes in certain situations. This is because the v2 compatibility layer and the connector used for ndc-test both require transforming the data, and so cannot work directly with bytes. We should not call this when running the connector normally, and it is not available outside this crate.