### PR TITLE
Add status code metrics

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -192,6 +192,8 @@ pub trait Connector {
     /// The type of unserializable state
     type State;
 
+    fn connector_name() -> String;
+
     fn make_empty_configuration() -> Self::RawConfiguration;
 
     async fn update_configuration(

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -15,6 +15,10 @@ impl Connector for Example {
     type Configuration = ();
     type State = ();
 
+    fn connector_name() -> String {
+        "ndc-example".to_string()
+    }
+
     fn make_empty_configuration() -> Self::RawConfiguration {}
 
     async fn update_configuration(

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -257,8 +257,7 @@ where
         .unwrap();
 
     let mut metrics_registry = Registry::new();
-    let metrics =
-        metrics::Metrics::initialize(&C::connector_name(), &mut metrics_registry).unwrap();
+    let metrics = metrics::Metrics::initialize(C::connector_name(), &mut metrics_registry).unwrap();
     let state = C::try_init_state(&configuration, &mut metrics_registry)
         .await
         .unwrap();

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -4,7 +4,7 @@ use crate::{
     check_health,
     connector::{Connector, InvalidRange, SchemaError, UpdateConfigurationError},
     json_response::JsonResponse,
-    routes,
+    metrics, routes,
     tracing::{init_tracing, make_span, on_response},
 };
 
@@ -130,7 +130,8 @@ type Port = u16;
 pub struct ServerState<C: Connector> {
     configuration: C::Configuration,
     state: C::State,
-    metrics: Registry,
+    metrics_registry: Registry,
+    metrics: metrics::Metrics,
 }
 
 /// A default main function for a connector.
@@ -255,14 +256,16 @@ where
         .await
         .unwrap();
 
-    let mut metrics = Registry::new();
-    let state = C::try_init_state(&configuration, &mut metrics)
+    let mut metrics_registry = Registry::new();
+    let metrics = metrics::Metrics::initialize(&mut metrics_registry).unwrap(); // todo: remove unwrap
+    let state = C::try_init_state(&configuration, &mut metrics_registry)
         .await
         .unwrap();
 
     ServerState::<C> {
         configuration,
         state,
+        metrics_registry,
         metrics,
     }
 }
@@ -384,7 +387,7 @@ where
 async fn get_metrics<C: Connector>(
     State(state): State<ServerState<C>>,
 ) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
-    routes::get_metrics::<C>(&state.configuration, &state.state, state.metrics)
+    routes::get_metrics::<C>(&state.configuration, &state.state, state.metrics_registry)
 }
 
 async fn get_capabilities<C: Connector>() -> JsonResponse<CapabilitiesResponse> {
@@ -400,28 +403,36 @@ async fn get_health<C: Connector>(
 async fn get_schema<C: Connector>(
     State(state): State<ServerState<C>>,
 ) -> Result<JsonResponse<SchemaResponse>, (StatusCode, Json<ErrorResponse>)> {
-    routes::get_schema::<C>(&state.configuration).await
+    state
+        .metrics
+        .record_status(routes::get_schema::<C>(&state.configuration).await)
 }
 
 async fn post_explain<C: Connector>(
     State(state): State<ServerState<C>>,
     request: Json<QueryRequest>,
 ) -> Result<JsonResponse<ExplainResponse>, (StatusCode, Json<ErrorResponse>)> {
-    routes::post_explain::<C>(&state.configuration, &state.state, request).await
+    state
+        .metrics
+        .record_status(routes::post_explain::<C>(&state.configuration, &state.state, request).await)
 }
 
 async fn post_mutation<C: Connector>(
     State(state): State<ServerState<C>>,
     request: Json<MutationRequest>,
 ) -> Result<JsonResponse<MutationResponse>, (StatusCode, Json<ErrorResponse>)> {
-    routes::post_mutation::<C>(&state.configuration, &state.state, request).await
+    state.metrics.record_status(
+        routes::post_mutation::<C>(&state.configuration, &state.state, request).await,
+    )
 }
 
 async fn post_query<C: Connector>(
     State(state): State<ServerState<C>>,
     request: Json<QueryRequest>,
 ) -> Result<JsonResponse<QueryResponse>, (StatusCode, Json<ErrorResponse>)> {
-    routes::post_query::<C>(&state.configuration, &state.state, request).await
+    state
+        .metrics
+        .record_status(routes::post_query::<C>(&state.configuration, &state.state, request).await)
 }
 
 async fn configuration<C: Connector + 'static>(

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -257,7 +257,8 @@ where
         .unwrap();
 
     let mut metrics_registry = Registry::new();
-    let metrics = metrics::Metrics::initialize(&mut metrics_registry).unwrap(); // todo: remove unwrap
+    let metrics =
+        metrics::Metrics::initialize(&C::connector_name(), &mut metrics_registry).unwrap();
     let state = C::try_init_state(&configuration, &mut metrics_registry)
         .await
         .unwrap();

--- a/rust-connector-sdk/src/lib.rs
+++ b/rust-connector-sdk/src/lib.rs
@@ -2,6 +2,7 @@ pub mod check_health;
 pub mod connector;
 pub mod default_main;
 pub mod json_response;
+pub mod metrics;
 pub mod routes;
 pub mod secret;
 pub mod tracing;

--- a/rust-connector-sdk/src/metrics.rs
+++ b/rust-connector-sdk/src/metrics.rs
@@ -50,67 +50,67 @@ impl Metrics {
 
         let total_200 = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_200_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_200_total_count", connector_name).as_str(),
             "Total number of 200 status codes returned.",
         )?;
 
         let total_400 = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_400_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_400_total_count", connector_name).as_str(),
             "Total number of 400 status codes returned.",
         )?;
 
         let total_403 = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_403_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_403_total_count", connector_name).as_str(),
             "Total number of 403 status codes returned.",
         )?;
 
         let total_409 = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_409_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_409_total_count", connector_name).as_str(),
             "Total number of 409 status codes returned.",
         )?;
 
         let total_500 = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_500_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_500_total_count", connector_name).as_str(),
             "Total number of 500 status codes returned.",
         )?;
 
         let total_501 = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_501_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_501_total_count", connector_name).as_str(),
             "Total number of 501 status codes returned.",
         )?;
 
         let total_1xx = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_1xx_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_1xx_total_count", connector_name).as_str(),
             "Total number of 1xx status codes returned.",
         )?;
 
         let total_2xx = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_2xx_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_2xx_total_count", connector_name).as_str(),
             "Total number of 2xx status codes returned.",
         )?;
 
         let total_3xx = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_3xx_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_3xx_total_count", connector_name).as_str(),
             "Total number of 3xx status codes returned.",
         )?;
 
         let total_4xx = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_4xx_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_4xx_total_count", connector_name).as_str(),
             "Total number of 4xx status codes returned.",
         )?;
 
         let total_5xx = add_int_counter_metric(
             metrics_registry,
-            format!("{}_status_code_5xx_total_count", connector_name).as_str(),
+            format!("hasura_{}_status_code_5xx_total_count", connector_name).as_str(),
             "Total number of 5xx status codes returned.",
         )?;
 

--- a/rust-connector-sdk/src/metrics.rs
+++ b/rust-connector-sdk/src/metrics.rs
@@ -29,37 +29,37 @@ impl Metrics {
     ) -> Result<Self, prometheus::Error> {
         let total_200 = add_int_counter_metric(
             metrics_registry,
-            "status_code_200",
+            "status_code_200_total_count",
             "Total number of 200 status codes returned.",
         )?;
 
         let total_400 = add_int_counter_metric(
             metrics_registry,
-            "status_code_400",
+            "status_code_400_total_count",
             "Total number of 400 status codes returned.",
         )?;
 
         let total_403 = add_int_counter_metric(
             metrics_registry,
-            "status_code_403",
+            "status_code_403_total_count",
             "Total number of 403 status codes returned.",
         )?;
 
         let total_409 = add_int_counter_metric(
             metrics_registry,
-            "status_code_409",
+            "status_code_409_total_count",
             "Total number of 409 status codes returned.",
         )?;
 
         let total_500 = add_int_counter_metric(
             metrics_registry,
-            "status_code_500",
+            "status_code_500_total_count",
             "Total number of 500 status codes returned.",
         )?;
 
         let total_501 = add_int_counter_metric(
             metrics_registry,
-            "status_code_501",
+            "status_code_501_total_count",
             "Total number of 501 status codes returned.",
         )?;
 

--- a/rust-connector-sdk/src/metrics.rs
+++ b/rust-connector-sdk/src/metrics.rs
@@ -30,9 +30,24 @@ pub struct StatusCodeMetrics {
 impl Metrics {
     /// Set up counters and gauges used to produce Prometheus metrics
     pub fn initialize(
-        connector_name: &str,
+        connector_name: String,
         metrics_registry: &mut prometheus::Registry,
     ) -> Result<Self, prometheus::Error> {
+        // Transform the connector name so it is a valid prometheus metric name
+        // <https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels>
+        let connector_name: String = connector_name
+            .chars()
+            .filter_map(|c| {
+                if c == '-' {
+                    Some('_')
+                } else if c.is_ascii_alphanumeric() {
+                    Some(c)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         let total_200 = add_int_counter_metric(
             metrics_registry,
             format!("{}_status_code_200_total_count", connector_name).as_str(),

--- a/rust-connector-sdk/src/metrics.rs
+++ b/rust-connector-sdk/src/metrics.rs
@@ -30,71 +30,72 @@ pub struct StatusCodeMetrics {
 impl Metrics {
     /// Set up counters and gauges used to produce Prometheus metrics
     pub fn initialize(
+        connector_name: &str,
         metrics_registry: &mut prometheus::Registry,
     ) -> Result<Self, prometheus::Error> {
         let total_200 = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_200_total_count",
+            format!("{}_status_code_200_total_count", connector_name).as_str(),
             "Total number of 200 status codes returned.",
         )?;
 
         let total_400 = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_400_total_count",
+            format!("{}_status_code_400_total_count", connector_name).as_str(),
             "Total number of 400 status codes returned.",
         )?;
 
         let total_403 = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_403_total_count",
+            format!("{}_status_code_403_total_count", connector_name).as_str(),
             "Total number of 403 status codes returned.",
         )?;
 
         let total_409 = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_409_total_count",
+            format!("{}_status_code_409_total_count", connector_name).as_str(),
             "Total number of 409 status codes returned.",
         )?;
 
         let total_500 = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_500_total_count",
+            format!("{}_status_code_500_total_count", connector_name).as_str(),
             "Total number of 500 status codes returned.",
         )?;
 
         let total_501 = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_501_total_count",
+            format!("{}_status_code_501_total_count", connector_name).as_str(),
             "Total number of 501 status codes returned.",
         )?;
 
         let total_1xx = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_1xx_total_count",
+            format!("{}_status_code_1xx_total_count", connector_name).as_str(),
             "Total number of 1xx status codes returned.",
         )?;
 
         let total_2xx = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_2xx_total_count",
+            format!("{}_status_code_2xx_total_count", connector_name).as_str(),
             "Total number of 2xx status codes returned.",
         )?;
 
         let total_3xx = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_3xx_total_count",
+            format!("{}_status_code_3xx_total_count", connector_name).as_str(),
             "Total number of 3xx status codes returned.",
         )?;
 
         let total_4xx = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_4xx_total_count",
+            format!("{}_status_code_4xx_total_count", connector_name).as_str(),
             "Total number of 4xx status codes returned.",
         )?;
 
         let total_5xx = add_int_counter_metric(
             metrics_registry,
-            "hasura_status_code_5xx_total_count",
+            format!("{}_status_code_5xx_total_count", connector_name).as_str(),
             "Total number of 5xx status codes returned.",
         )?;
 

--- a/rust-connector-sdk/src/metrics.rs
+++ b/rust-connector-sdk/src/metrics.rs
@@ -1,0 +1,145 @@
+//! Some metrics setup and update.
+
+use crate::json_response::JsonResponse;
+use axum::{http::StatusCode, Json};
+use ndc_client::models::ErrorResponse;
+use prometheus;
+
+/// The collection of some metrics exposed through the `/metrics` endpoint.
+#[derive(Debug, Clone)]
+pub struct Metrics {
+    status_codes: StatusCodeMetrics,
+}
+
+/// The collection of some metrics exposed through the `/metrics` endpoint.
+#[derive(Debug, Clone)]
+pub struct StatusCodeMetrics {
+    total_200: prometheus::IntCounter,
+    total_400: prometheus::IntCounter,
+    total_403: prometheus::IntCounter,
+    total_409: prometheus::IntCounter,
+    total_500: prometheus::IntCounter,
+    total_501: prometheus::IntCounter,
+}
+
+impl Metrics {
+    /// Set up counters and gauges used to produce Prometheus metrics
+    pub fn initialize(
+        metrics_registry: &mut prometheus::Registry,
+    ) -> Result<Self, prometheus::Error> {
+        let total_200 = add_int_counter_metric(
+            metrics_registry,
+            "status_code_200",
+            "Total number of 200 status codes returned.",
+        )?;
+
+        let total_400 = add_int_counter_metric(
+            metrics_registry,
+            "status_code_400",
+            "Total number of 400 status codes returned.",
+        )?;
+
+        let total_403 = add_int_counter_metric(
+            metrics_registry,
+            "status_code_403",
+            "Total number of 403 status codes returned.",
+        )?;
+
+        let total_409 = add_int_counter_metric(
+            metrics_registry,
+            "status_code_409",
+            "Total number of 409 status codes returned.",
+        )?;
+
+        let total_500 = add_int_counter_metric(
+            metrics_registry,
+            "status_code_500",
+            "Total number of 500 status codes returned.",
+        )?;
+
+        let total_501 = add_int_counter_metric(
+            metrics_registry,
+            "status_code_501",
+            "Total number of 501 status codes returned.",
+        )?;
+
+        let status_codes = StatusCodeMetrics {
+            total_200,
+            total_400,
+            total_403,
+            total_409,
+            total_500,
+            total_501,
+        };
+
+        Ok(Self { status_codes })
+    }
+
+    /// record a status code from an api result.
+    pub fn record_status<T>(
+        &self,
+        result: Result<JsonResponse<T>, (StatusCode, Json<ErrorResponse>)>,
+    ) -> Result<JsonResponse<T>, (StatusCode, Json<ErrorResponse>)> {
+        match result {
+            Ok(result) => {
+                self.record_status_code(StatusCode::OK);
+                Ok(result)
+            }
+            Err((status_code, result)) => {
+                self.record_status_code(status_code);
+                Err((status_code, result))
+            }
+        }
+    }
+
+    fn record_status_code(&self, status_code: StatusCode) {
+        match status_code {
+            StatusCode::OK => self.record_200(),
+            StatusCode::BAD_REQUEST => self.record_400(),
+            StatusCode::FORBIDDEN => self.record_403(),
+            StatusCode::CONFLICT => self.record_409(),
+            StatusCode::INTERNAL_SERVER_ERROR => self.record_500(),
+            StatusCode::NOT_IMPLEMENTED => self.record_501(),
+            _ => (),
+        }
+    }
+
+    fn record_200(&self) {
+        self.status_codes.total_200.inc()
+    }
+    fn record_400(&self) {
+        self.status_codes.total_400.inc()
+    }
+    fn record_403(&self) {
+        self.status_codes.total_403.inc()
+    }
+    fn record_409(&self) {
+        self.status_codes.total_409.inc()
+    }
+    fn record_500(&self) {
+        self.status_codes.total_500.inc()
+    }
+    fn record_501(&self) {
+        self.status_codes.total_501.inc()
+    }
+}
+
+/// Create a new int counter metric and register it with the provided Prometheus Registry
+fn add_int_counter_metric(
+    metrics_registry: &mut prometheus::Registry,
+    metric_name: &str,
+    metric_description: &str,
+) -> Result<prometheus::IntCounter, prometheus::Error> {
+    let int_counter =
+        prometheus::IntCounter::with_opts(prometheus::Opts::new(metric_name, metric_description))?;
+    register_collector(metrics_registry, int_counter)
+}
+
+/// Register a new collector with the registry, and returns it for later use.
+fn register_collector<Collector: prometheus::core::Collector + std::clone::Clone + 'static>(
+    metrics_registry: &mut prometheus::Registry,
+    collector: Collector,
+) -> Result<Collector, prometheus::Error> {
+    metrics_registry.register(Box::new(collector.clone()))?;
+    Ok(collector)
+}

--- a/rust-connector-sdk/src/routes.rs
+++ b/rust-connector-sdk/src/routes.rs
@@ -10,7 +10,7 @@ use crate::{
 pub fn get_metrics<C: Connector>(
     configuration: &C::Configuration,
     state: &C::State,
-    metrics: Registry,
+    metrics_registry: Registry,
 ) -> Result<String, (StatusCode, Json<models::ErrorResponse>)> {
     let encoder = TextEncoder::new();
 
@@ -25,7 +25,7 @@ pub fn get_metrics<C: Connector>(
         )
     })?;
 
-    let metric_families = metrics.gather();
+    let metric_families = metrics_registry.gather();
 
     encoder.encode_to_string(&metric_families).map_err(|_| {
         (


### PR DESCRIPTION
## What

https://hasurahq.atlassian.net/browse/NDAT-1006

We'd like to track the status codes returned by a connector in metrics.

## How

From the metrics registry created by ndc-sdk, create a metrics struct that will contain a counter for each status code we [want to track](https://hasura.github.io/ndc-spec/specification/error-handling.html), and increment those on each relevant API call (query, explain, etc.). We also include group buckets for 1xx, 2xx, etc.

An alternative to this approach would be to create a middleware that would count all responses, though these will also include health checks, missing api calls, metrics api calls, etc. Which I thought would muddle the metrics we actually care about.

We also add a new function to the Connector trait - `fn connector_name() -> String`, so we can use it to create metrics names for the connector.