### PR TITLE
Organize the imports consistently.

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -1,7 +1,8 @@
+use std::error::Error;
+
 use async_trait::async_trait;
 use ndc_client::models;
 use serde::Serialize;
-use std::error::Error;
 use thiserror::Error;
 
 use crate::json_response::JsonResponse;

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -1,12 +1,9 @@
 mod v2_compat;
 
-use crate::{
-    check_health,
-    connector::{Connector, InvalidRange, SchemaError, UpdateConfigurationError},
-    json_response::JsonResponse,
-    routes,
-    tracing::{init_tracing, make_span, on_response},
-};
+use std::error::Error;
+use std::net;
+use std::path::PathBuf;
+use std::process::exit;
 
 use async_trait::async_trait;
 use axum::{
@@ -29,12 +26,13 @@ use ndc_test::report;
 use prometheus::Registry;
 use schemars::{schema::RootSchema, JsonSchema};
 use serde::{de::DeserializeOwned, Serialize};
-use std::net;
-use std::process::exit;
-use std::{error::Error, path::PathBuf};
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
-use self::v2_compat::SourceConfig;
+use crate::check_health;
+use crate::connector::{Connector, InvalidRange, SchemaError, UpdateConfigurationError};
+use crate::json_response::JsonResponse;
+use crate::routes;
+use crate::tracing::{init_tracing, make_span, on_response};
 
 #[derive(Parser)]
 struct CliArgs {
@@ -348,7 +346,8 @@ where
                     .headers()
                     .get("x-hasura-dataconnector-config")
                     .and_then(|config_header| {
-                        serde_json::from_slice::<SourceConfig>(config_header.as_bytes()).ok()
+                        serde_json::from_slice::<v2_compat::SourceConfig>(config_header.as_bytes())
+                            .ok()
                     })
                     .and_then(|config| config.service_token_secret);
 

--- a/rust-connector-sdk/src/default_main/v2_compat.rs
+++ b/rust-connector-sdk/src/default_main/v2_compat.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use gdc_rust_types::{
     Aggregate, BinaryArrayComparisonOperator, BinaryComparisonOperator, Capabilities,
@@ -14,7 +16,6 @@ use indexmap::IndexMap;
 use ndc_client::models;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::BTreeMap;
 
 use crate::connector::{Connector, ExplainError, QueryError};
 use crate::default_main::ServerState;

--- a/rust-connector-sdk/src/secret.rs
+++ b/rust-connector-sdk/src/secret.rs
@@ -1,4 +1,4 @@
-use schemars::{self, schema::Schema, JsonSchema};
+use schemars::{schema::Schema, JsonSchema};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
@@ -53,7 +53,7 @@ mod tests {
     pub fn test_json_schema() {
         let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
-        let mut mint = Mint::new(&test_dir);
+        let mut mint = Mint::new(test_dir);
 
         let expected_path = PathBuf::from_iter(["json_schema", "secret_value.jsonschema"]);
 

--- a/rust-connector-sdk/src/tracing.rs
+++ b/rust-connector-sdk/src/tracing.rs
@@ -1,19 +1,17 @@
-use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
-use opentelemetry_api::KeyValue;
-use opentelemetry_otlp::{WithExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT};
-use opentelemetry_sdk::trace::Sampler;
 use std::env;
 use std::error::Error;
-use tracing_subscriber::EnvFilter;
+use std::time::Duration;
 
 use axum::body::{Body, BoxBody};
 use http::{Request, Response};
+use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
+use opentelemetry_api::KeyValue;
 use opentelemetry_http::HeaderExtractor;
-use std::time::Duration;
+use opentelemetry_otlp::{WithExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT};
+use opentelemetry_sdk::trace::Sampler;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 pub fn init_tracing(
     service_name: &Option<String>,


### PR DESCRIPTION
They were kind of all over the place, so I've gone for:

1. `std`
2. everything else
3. `crate`