### PR TITLE
return extraction errors as json ErrorResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab90e7b70bea63a153137162affb6a0bce26b584c24a4c7885509783e2cf30b"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-test-helper"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1067,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
+ "axum-extra",
  "axum-test-helper",
  "base64 0.21.5",
  "bytes",

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -18,6 +18,7 @@ ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.9" 
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"
+axum-extra = "^0.8.0"
 base64 = "0.21.5"
 bytes = "1.5.0"
 clap = { version = "^4.4.7", features = ["derive", "env"] }

--- a/rust-connector-sdk/src/json_rejection.rs
+++ b/rust-connector-sdk/src/json_rejection.rs
@@ -1,0 +1,28 @@
+//! We want errors returned from failed json extractors to be formatted as json as well.
+
+use axum::extract;
+use axum::{http::StatusCode, response::IntoResponse};
+
+pub struct JsonRejection {
+    message: String,
+    status: StatusCode,
+}
+
+impl From<extract::rejection::JsonRejection> for JsonRejection {
+    fn from(rejection: extract::rejection::JsonRejection) -> JsonRejection {
+        JsonRejection {
+            message: rejection.body_text(),
+            status: rejection.status(),
+        }
+    }
+}
+
+impl IntoResponse for JsonRejection {
+    fn into_response(self) -> axum::response::Response {
+        let payload = serde_json::json!({
+            "error": self.message,
+        });
+
+        (self.status, extract::Json(payload)).into_response()
+    }
+}

--- a/rust-connector-sdk/src/lib.rs
+++ b/rust-connector-sdk/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod check_health;
 pub mod connector;
 pub mod default_main;
+pub mod json_rejection;
 pub mod json_response;
 pub mod routes;
 pub mod secret;

--- a/rust-connector-sdk/src/routes.rs
+++ b/rust-connector-sdk/src/routes.rs
@@ -79,7 +79,7 @@ pub async fn get_schema<C: Connector>(
 pub async fn post_explain<C: Connector>(
     configuration: &C::Configuration,
     state: &C::State,
-    Json(request): Json<models::QueryRequest>,
+    request: models::QueryRequest,
 ) -> Result<JsonResponse<models::ExplainResponse>, (StatusCode, Json<models::ErrorResponse>)> {
     C::explain(configuration, state, request)
         .await
@@ -120,7 +120,7 @@ pub async fn post_explain<C: Connector>(
 pub async fn post_mutation<C: Connector>(
     configuration: &C::Configuration,
     state: &C::State,
-    Json(request): Json<models::MutationRequest>,
+    request: models::MutationRequest,
 ) -> Result<JsonResponse<models::MutationResponse>, (StatusCode, Json<models::ErrorResponse>)> {
     C::mutation(configuration, state, request)
         .await
@@ -181,7 +181,7 @@ pub async fn post_mutation<C: Connector>(
 pub async fn post_query<C: Connector>(
     configuration: &C::Configuration,
     state: &C::State,
-    Json(request): Json<models::QueryRequest>,
+    request: models::QueryRequest,
 ) -> Result<JsonResponse<models::QueryResponse>, (StatusCode, Json<models::ErrorResponse>)> {
     C::query(configuration, state, request)
         .await


### PR DESCRIPTION
## What

[We'd like](https://hasurahq.slack.com/archives/C04NS5JCD8A/p1697618175968319?thread_ts=1697551776.418919&cid=C04NS5JCD8A) to return a json [ErrorResponse](https://hasura.github.io/ndc-spec/reference/types.html#errorresponse) on extract errors instead of plain text error messages.

With this PR, we'll return (for example):

```json
{
  "message": "Parse error",
  "details": "Failed to deserialize the JSON body into the target type: query.where.type: unknown variant `inary_comparison_operator`, expected one of `and`, `or`, `not`, `unary_comparison_operator`, `binary_comparison_operator`, `binary_array_comparison_operator`, `exists` at line 1 column 210"
}
```

## How

We use [WithRejection](https://docs.rs/axum-extra/latest/axum_extra/extract/struct.WithRejection.html) to apply a transformation to the errors that the normal `Json` extractor emits, and wrap them in a json object.