### PR TITLE
return capabilities in /validate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.10#5cc5039cf96ff24eae275d8706d1b159d7fc66b5"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.11#3ef71ffecbba088ebb5f452114b2dc662f1b9d3f"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",
@@ -1104,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.10#5cc5039cf96ff24eae275d8706d1b159d7fc66b5"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.11#3ef71ffecbba088ebb5f452114b2dc662f1b9d3f"
 dependencies = [
  "async-trait",
  "clap",

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -13,8 +13,8 @@ path = "bin/main.rs"
 
 [dependencies]
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types.git", rev = "3273434" }
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.10" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.10" }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.11" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.11" }
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -56,11 +56,10 @@ impl Connector for Example {
             capabilities: models::Capabilities {
                 explain: None,
                 relationships: None,
-                query: Some(models::QueryCapabilities {
-                    foreach: None,
-                    order_by_aggregate: None,
-                    relation_comparisons: None,
-                }),
+                query: models::QueryCapabilities {
+                    variables: None,
+                    aggregates: None,
+                },
             },
         }
         .into()

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -577,6 +577,7 @@ where
 #[derive(Debug, Clone, Serialize)]
 struct ValidateResponse {
     schema: SchemaResponse,
+    capabilities: CapabilitiesResponse,
     resolved_configuration: String,
 }
 
@@ -585,6 +586,7 @@ struct ValidateResponse {
 enum ValidateErrors {
     InvalidConfiguration { ranges: Vec<InvalidRange> },
     UnableToBuildSchema,
+    UnableToBuildCapabilities,
     JsonEncodingError(String),
 }
 
@@ -623,6 +625,24 @@ where
                 )
             }
         })?;
+    let capabilities =
+        C::get_capabilities()
+            .await
+            .into_value()
+            .map_err(|e: Box<dyn Error + Send + Sync>| {
+                tracing::error!(
+                    meta.signal_type = "log",
+                    event.domain = "ndc",
+                    event.name = "Unable to build schema",
+                    name = "Unable to build schema",
+                    body = %e,
+                    error = true,
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ValidateErrors::UnableToBuildCapabilities),
+                )
+            })?;
     let resolved_config_bytes = serde_json::to_vec(&configuration).map_err(|err| {
         tracing::error!(
             meta.signal_type = "log",
@@ -640,6 +660,7 @@ where
     let resolved_configuration = general_purpose::STANDARD.encode(resolved_config_bytes);
     Ok(Json(ValidateResponse {
         schema,
+        capabilities,
         resolved_configuration,
     }))
 }

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -633,8 +633,8 @@ where
                 tracing::error!(
                     meta.signal_type = "log",
                     event.domain = "ndc",
-                    event.name = "Unable to build schema",
-                    name = "Unable to build schema",
+                    event.name = "Unable to build capabilities",
+                    name = "Unable to build capabilities",
                     body = %e,
                     error = true,
                 );

--- a/rust-connector-sdk/src/default_main/v2_compat.rs
+++ b/rust-connector-sdk/src/default_main/v2_compat.rs
@@ -94,7 +94,7 @@ pub async fn get_capabilities<C: Connector>(
                 subquery: Some(SubqueryComparisonCapabilities {
                     supports_relations: v3_capabilities
                         .capabilities
-                        .query
+                        .relationships
                         .as_ref()
                         .map(|capabilities| capabilities.relation_comparisons.is_some()),
                 }),


### PR DESCRIPTION
We want to start respecting connector capabilities in the engine, so we need them when building metadata in MBS using /validate.