### PR TITLE
update ndc-spec dependency to `v0.1.0-rc.12`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.11#3ef71ffecbba088ebb5f452114b2dc662f1b9d3f"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.12#0e84462f98fdf77e1f25ab905e33918aaef4cee9"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",
@@ -1104,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.11#3ef71ffecbba088ebb5f452114b2dc662f1b9d3f"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.12#0e84462f98fdf77e1f25ab905e33918aaef4cee9"
 dependencies = [
  "async-trait",
  "clap",

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -13,8 +13,8 @@ path = "bin/main.rs"
 
 [dependencies]
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types.git", rev = "3273434" }
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.11" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.11" }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.12" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.12" }
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"


### PR DESCRIPTION
This PR updates the ndc-spec dependency to use the latest tag.