### PR TITLE
Add an 'UnprocessableContent' error

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -89,7 +89,7 @@ pub enum QueryError {
     /// an error with the client.
     #[error("invalid request: {0}")]
     InvalidRequest(String),
-    /// The request was well formed but was unabled to be
+    /// The request was well formed but was unable to be
     /// followed due to semantic errors. This indicates
     /// an error with the client.
     #[error("unprocessable content: {0}")]

--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -113,7 +113,7 @@ pub enum ExplainError {
     /// an error with the client.
     #[error("invalid request: {0}")]
     InvalidRequest(String),
-    /// The request was well formed but was unabled to be
+    /// The request was well formed but was unable to be
     /// followed due to semantic errors. This indicates
     /// an error with the client.
     #[error("unprocessable content: {0}")]
@@ -137,7 +137,7 @@ pub enum MutationError {
     /// an error with the client.
     #[error("invalid request: {0}")]
     InvalidRequest(String),
-    /// The request was well formed but was unabled to be
+    /// The request was well formed but was unable to be
     /// followed due to semantic errors. This indicates
     /// an error with the client.
     #[error("unprocessable content: {0}")]

--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -89,6 +89,11 @@ pub enum QueryError {
     /// an error with the client.
     #[error("invalid request: {0}")]
     InvalidRequest(String),
+    /// The request was well formed but was unabled to be
+    /// followed due to semantic errors. This indicates
+    /// an error with the client.
+    #[error("unprocessable content: {0}")]
+    UnprocessableContent(String),
     /// The request relies on an unsupported feature or
     /// capability. This may indicate an error with the client,
     /// or just an unimplemented feature.
@@ -108,6 +113,11 @@ pub enum ExplainError {
     /// an error with the client.
     #[error("invalid request: {0}")]
     InvalidRequest(String),
+    /// The request was well formed but was unabled to be
+    /// followed due to semantic errors. This indicates
+    /// an error with the client.
+    #[error("unprocessable content: {0}")]
+    UnprocessableContent(String),
     /// The request relies on an unsupported feature or
     /// capability. This may indicate an error with the client,
     /// or just an unimplemented feature.
@@ -127,6 +137,11 @@ pub enum MutationError {
     /// an error with the client.
     #[error("invalid request: {0}")]
     InvalidRequest(String),
+    /// The request was well formed but was unabled to be
+    /// followed due to semantic errors. This indicates
+    /// an error with the client.
+    #[error("unprocessable content: {0}")]
+    UnprocessableContent(String),
     /// The request relies on an unsupported feature or
     /// capability. This may indicate an error with the client,
     /// or just an unimplemented feature.

--- a/rust-connector-sdk/src/default_main/v2_compat.rs
+++ b/rust-connector-sdk/src/default_main/v2_compat.rs
@@ -367,7 +367,9 @@ pub async fn post_query<C: Connector>(
         .await
         .and_then(JsonResponse::into_value)
         .map_err(|err| match err {
-            QueryError::InvalidRequest(message) | QueryError::UnsupportedOperation(message) => (
+            QueryError::InvalidRequest(message)
+            | QueryError::UnsupportedOperation(message)
+            | QueryError::UnprocessableContent(message) => (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
                     details: None,
@@ -417,16 +419,16 @@ pub async fn post_explain<C: Connector>(
         .await
         .and_then(JsonResponse::into_value)
         .map_err(|err| match err {
-            ExplainError::InvalidRequest(message) | ExplainError::UnsupportedOperation(message) => {
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse {
-                        details: None,
-                        message,
-                        r#type: None,
-                    }),
-                )
-            }
+            ExplainError::InvalidRequest(message)
+            | ExplainError::UnsupportedOperation(message)
+            | ExplainError::UnprocessableContent(message) => (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    details: None,
+                    message,
+                    r#type: None,
+                }),
+            ),
             ExplainError::Other(err) => (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {

--- a/rust-connector-sdk/src/routes.rs
+++ b/rust-connector-sdk/src/routes.rs
@@ -104,6 +104,16 @@ pub async fn post_explain<C: Connector>(
                     )])),
                 }),
             ),
+            crate::connector::ExplainError::UnprocessableContent(detail) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(models::ErrorResponse {
+                    message: "Unprocessable content".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
             crate::connector::ExplainError::UnsupportedOperation(detail) => (
                 StatusCode::NOT_IMPLEMENTED,
                 Json(models::ErrorResponse {
@@ -139,6 +149,16 @@ pub async fn post_mutation<C: Connector>(
                 StatusCode::BAD_REQUEST,
                 Json(models::ErrorResponse {
                     message: "Invalid request".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+            crate::connector::MutationError::UnprocessableContent(detail) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(models::ErrorResponse {
+                    message: "Unprocessable content".into(),
                     details: serde_json::Value::Object(serde_json::Map::from_iter([(
                         "detail".into(),
                         serde_json::Value::String(detail),
@@ -200,6 +220,16 @@ pub async fn post_query<C: Connector>(
                 StatusCode::BAD_REQUEST,
                 Json(models::ErrorResponse {
                     message: "Invalid request".into(),
+                    details: serde_json::Value::Object(serde_json::Map::from_iter([(
+                        "detail".into(),
+                        serde_json::Value::String(detail),
+                    )])),
+                }),
+            ),
+            crate::connector::QueryError::UnprocessableContent(detail) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(models::ErrorResponse {
+                    message: "Unprocessable content".into(),
                     details: serde_json::Value::Object(serde_json::Map::from_iter([(
                         "detail".into(),
                         serde_json::Value::String(detail),


### PR DESCRIPTION
## What

We want to be able to return 422 error codes on cases such as the following query:

```graphql
query MyQuery {
  ArtistByArtistId(ArtistId: "") {
    Name
  }
}
```

Where the user provides an invalid value - `ArtistId` is expected to be an integer, but the user provided an empty string.

## How

To do that we add a new error variant for QueryError, ExplainError and MutationError which will be mapped to that status code 422.