### PR TITLE
CI: Copy Cargo.lock into the build image to pin dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 ENV CARGO_HOME=/app/.cargo
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=lld"
 
+COPY Cargo.lock .
 COPY ./rust-connector-sdk .
 
 RUN cargo build --release


### PR DESCRIPTION
Otherwise we're not testing what we expect.