### PR TITLE
Remove constraints from `default_main` where possible.

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -202,11 +202,11 @@ pub enum MutationError {
 #[async_trait]
 pub trait Connector {
     /// The type of unvalidated, raw configuration, as provided by the user.
-    type RawConfiguration;
+    type RawConfiguration: Sync + Send;
     /// The type of validated configuration
-    type Configuration;
+    type Configuration: Sync + Send;
     /// The type of unserializable state
-    type State;
+    type State: Sync + Send;
 
     fn make_empty_configuration() -> Self::RawConfiguration;
 

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -128,11 +128,25 @@ struct CheckHealthCommand {
 
 type Port = u16;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ServerState<C: Connector> {
     configuration: C::Configuration,
     state: C::State,
     metrics: Registry,
+}
+
+impl<C: Connector> Clone for ServerState<C>
+where
+    C::Configuration: Clone,
+    C::State: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            configuration: self.configuration.clone(),
+            state: self.state.clone(),
+            metrics: self.metrics.clone(),
+        }
+    }
 }
 
 /// A default main function for a connector.
@@ -158,7 +172,7 @@ pub struct ServerState<C: Connector> {
 /// - It reads configuration as JSON from a file specified on the command line,
 /// - It reports traces to an OTLP collector specified on the command line,
 /// - Logs are written to stdout
-pub async fn default_main<C: Connector + Clone + Default + 'static>(
+pub async fn default_main<C: Connector + Default + 'static>(
 ) -> Result<(), Box<dyn Error + Send + Sync>>
 where
     C::RawConfiguration: Serialize + DeserializeOwned + JsonSchema + Sync + Send,
@@ -176,7 +190,7 @@ where
     }
 }
 
-async fn serve<C: Connector + Clone + Default + 'static>(
+async fn serve<C: Connector + Default + 'static>(
     serve_command: ServeCommand,
 ) -> Result<(), Box<dyn Error + Send + Sync>>
 where
@@ -242,7 +256,7 @@ where
 }
 
 /// Initialize the server state from the configuration file.
-pub async fn init_server_state<C: Connector + Clone + Default + 'static>(
+pub async fn init_server_state<C: Connector + Default + 'static>(
     config_file: impl AsRef<Path>,
 ) -> ServerState<C>
 where
@@ -269,7 +283,7 @@ where
     }
 }
 
-pub fn create_router<C: Connector + Clone + 'static>(
+pub fn create_router<C: Connector + 'static>(
     state: ServerState<C>,
     service_token_secret: Option<String>,
 ) -> Router
@@ -350,7 +364,7 @@ where
         ))
 }
 
-pub fn create_v2_router<C: Connector + Clone + 'static>(
+pub fn create_v2_router<C: Connector + 'static>(
     state: ServerState<C>,
     service_token_secret: Option<String>,
 ) -> Router


### PR DESCRIPTION
I have made a few changes here.

1. I moved `Sync + Send` to the connector type constraints, because they're so basic that I can't imagine a connector working without them.
2. I removed the constraint on connectors themselves being cloneable by manually implementing `Clone` on `ServerState`.
3. I removed all unused constraints that I could find.