### PR TITLE
Rename and extend `ValidateError`.

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -18,7 +18,7 @@ pub mod example;
 #[derive(Debug, Error)]
 pub enum ParseError {
     #[error("error parsing configuration: {0}")]
-    ParseError(Position),
+    ParseError(LocatedError),
     #[error("error validating configuration: {0}")]
     ValidateError(InvalidPaths),
     #[error("error processing configuration: {0}")]
@@ -29,20 +29,22 @@ pub enum ParseError {
 
 /// The position of a single character in a text file.
 #[derive(Debug, Clone)]
-pub struct Position {
+pub struct LocatedError {
     pub path: PathBuf,
     pub line: usize,
     pub column: usize,
+    pub message: String,
 }
 
-impl Display for Position {
+impl Display for LocatedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{0}:{1}:{2}",
+            "{0}:{1}:{2}: {3}",
             self.path.display(),
             self.line,
-            self.column
+            self.column,
+            self.message
         )
     }
 }

--- a/rust-connector-sdk/src/connector/example.rs
+++ b/rust-connector-sdk/src/connector/example.rs
@@ -16,7 +16,7 @@ impl Connector for Example {
 
     async fn parse_configuration(
         _configuration_dir: impl AsRef<Path> + Send,
-    ) -> Result<Self::Configuration, ValidateError> {
+    ) -> Result<Self::Configuration, ParseError> {
         Ok(())
     }
 


### PR DESCRIPTION
We now need to conduct I/O during `parse_configuration`, which means the current `ValidateError` isn't quite enough.

I've renamed it to `ParseError` (to complement `parse_configuration`), and added a few extra cases.

1. `ParseError`, which denotes the file path and position where parsing failed.
2. `ValidateError`, as before, but including the file path, wrapping the vector in `InvalidNodes` so we can implement `Display`.
3. `IoError`, for when we fail to read a file.
4. `Other`, because I can't think of everything.

I am using the first 3 in integrating the latest changes into ndc-postgres.