### PR TITLE
Update spec for test changes, add "bench" subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?rev=cf9f8d2350618b595b7d030eaa1cf0d5312726a1#cf9f8d2350618b595b7d030eaa1cf0d5312726a1"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.19#0c7f807d331ad8324d8edcf6f7c4c9958e47e3b1"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?rev=cf9f8d2350618b595b7d030eaa1cf0d5312726a1#cf9f8d2350618b595b7d030eaa1cf0d5312726a1"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.19#0c7f807d331ad8324d8edcf6f7c4c9958e47e3b1"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?rev=d8f6160b577820db5adaa987c6c70587dd463c47#d8f6160b577820db5adaa987c6c70587dd463c47"
+source = "git+http://github.com/hasura/ndc-spec.git?rev=cf9f8d2350618b595b7d030eaa1cf0d5312726a1#cf9f8d2350618b595b7d030eaa1cf0d5312726a1"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?rev=d8f6160b577820db5adaa987c6c70587dd463c47#d8f6160b577820db5adaa987c6c70587dd463c47"
+source = "git+http://github.com/hasura/ndc-spec.git?rev=cf9f8d2350618b595b7d030eaa1cf0d5312726a1#cf9f8d2350618b595b7d030eaa1cf0d5312726a1"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.19#0c7f807d331ad8324d8edcf6f7c4c9958e47e3b1"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0#8892f0524affd37e94097c2ce43da8740fc57aca"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.19#0c7f807d331ad8324d8edcf6f7c4c9958e47e3b1"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0#8892f0524affd37e94097c2ce43da8740fc57aca"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,21 +228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,12 +929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
-name = "libm"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18#608ecc4b6719753c186a37494bbe95ae26e64f45"
+source = "git+http://github.com/hasura/ndc-spec.git?rev=0a7052750b705863419feadf2c80bd9a38a64923#0a7052750b705863419feadf2c80bd9a38a64923"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",
@@ -1102,14 +1081,14 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18#608ecc4b6719753c186a37494bbe95ae26e64f45"
+source = "git+http://github.com/hasura/ndc-spec.git?rev=0a7052750b705863419feadf2c80bd9a38a64923#0a7052750b705863419feadf2c80bd9a38a64923"
 dependencies = [
  "async-trait",
  "clap",
  "colored",
  "indexmap 2.1.0",
  "ndc-client",
- "proptest",
+ "rand",
  "reqwest",
  "semver",
  "serde",
@@ -1135,7 +1114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1435,26 +1413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags 2.4.1",
- "lazy_static",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax 0.7.5",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,12 +1440,6 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1526,15 +1478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1655,18 +1598,6 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -2369,12 +2300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,15 +2375,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?rev=0a7052750b705863419feadf2c80bd9a38a64923#0a7052750b705863419feadf2c80bd9a38a64923"
+source = "git+http://github.com/hasura/ndc-spec.git?rev=d8f6160b577820db5adaa987c6c70587dd463c47#d8f6160b577820db5adaa987c6c70587dd463c47"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?rev=0a7052750b705863419feadf2c80bd9a38a64923#0a7052750b705863419feadf2c80bd9a38a64923"
+source = "git+http://github.com/hasura/ndc-spec.git?rev=d8f6160b577820db5adaa987c6c70587dd463c47#d8f6160b577820db5adaa987c6c70587dd463c47"
 dependencies = [
  "async-trait",
  "clap",

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -13,8 +13,8 @@ path = "bin/main.rs"
 
 [dependencies]
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types.git", rev = "3273434" }
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", rev = "0a7052750b705863419feadf2c80bd9a38a64923" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", rev = "0a7052750b705863419feadf2c80bd9a38a64923" }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", rev = "d8f6160b577820db5adaa987c6c70587dd463c47" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", rev = "d8f6160b577820db5adaa987c6c70587dd463c47" }
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -13,8 +13,8 @@ path = "bin/main.rs"
 
 [dependencies]
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types.git", rev = "3273434" }
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", rev = "cf9f8d2350618b595b7d030eaa1cf0d5312726a1" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", rev = "cf9f8d2350618b595b7d030eaa1cf0d5312726a1" }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.19" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.19" }
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -13,8 +13,8 @@ path = "bin/main.rs"
 
 [dependencies]
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types.git", rev = "3273434" }
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", rev = "0a7052750b705863419feadf2c80bd9a38a64923" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", rev = "0a7052750b705863419feadf2c80bd9a38a64923" }
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -13,8 +13,8 @@ path = "bin/main.rs"
 
 [dependencies]
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types.git", rev = "3273434" }
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", rev = "d8f6160b577820db5adaa987c6c70587dd463c47" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", rev = "d8f6160b577820db5adaa987c6c70587dd463c47" }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", rev = "cf9f8d2350618b595b7d030eaa1cf0d5312726a1" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", rev = "cf9f8d2350618b595b7d030eaa1cf0d5312726a1" }
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -17,8 +17,8 @@ default = ["ndc-test"]
 
 [dependencies]
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types.git", rev = "3273434" }
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.19" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.19", optional = true }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0", optional = true }
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -11,10 +11,14 @@ path = "src/lib.rs"
 name = "ndc_hub_example"
 path = "bin/main.rs"
 
+[features]
+ndc-test = ["dep:ndc-test"]
+default = ["ndc-test"]
+
 [dependencies]
 gdc_rust_types = { git = "https://github.com/hasura/gdc_rust_types.git", rev = "3273434" }
 ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.19" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.19" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.19", optional = true }
 
 async-trait = "^0.1.74"
 axum = "^0.6.20"

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -545,8 +545,8 @@ async fn test<Setup: ConnectorSetup>(
     ndc_test::test_connector(&test_configuration, &connector, &mut reporter).await;
 
     if !reporter.1.failures.is_empty() {
-        // println!();
-        // println!("{}", report(reporter.1));
+        println!();
+        println!("{}", reporter.1.report());
 
         exit(1)
     }
@@ -564,8 +564,8 @@ async fn replay<Setup: ConnectorSetup>(
     ndc_test::test_snapshots_in_directory(&connector, &mut reporter, command.snapshots_dir).await;
 
     if !reporter.1.failures.is_empty() {
-        // println!();
-        // println!("{}", report(reporter.1));
+        println!();
+        println!("{}", reporter.1.report());
 
         exit(1)
     }

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -491,7 +491,9 @@ impl<C: Connector> ndc_test::connector::Connector for ConnectorAdapter<C> {
             .map_err(|err| ndc_test::error::Error::OtherError(err))
     }
 
-    async fn get_schema(&self) -> Result<ndc_client::models::SchemaResponse, ndc_test::error::Error> {
+    async fn get_schema(
+        &self,
+    ) -> Result<ndc_client::models::SchemaResponse, ndc_test::error::Error> {
         match C::get_schema(&self.configuration).await {
             Ok(response) => response
                 .into_value::<Box<dyn std::error::Error + Send + Sync>>()

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -608,7 +608,7 @@ async fn bench<Setup: ConnectorSetup>(
     let connector = make_connector_adapter(setup, command.configuration).await?;
     let mut reporter = (ConsoleReporter::new(), TestResults::default());
 
-    ndc_test::bench_snapshots_in_directory(
+    let reports = ndc_test::bench_snapshots_in_directory(
         &configuration,
         &connector,
         &mut reporter,
@@ -617,11 +617,11 @@ async fn bench<Setup: ConnectorSetup>(
     .await
     .map_err(|e| e.to_string())?;
 
-    if !reporter.1.failures.is_empty() {
-        println!();
-        println!("{}", reporter.1.report());
+    println!();
+    println!("{}", ndc_test::benchmark_report(&configuration, reports));
 
-        exit(1)
+    if !reporter.1.failures.is_empty() {
+        exit(1);
     }
 
     Ok(())

--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -567,7 +567,7 @@ mod ndc_test_commands {
         }
     }
 
-    pub async fn test<Setup: super::ConnectorSetup>(
+    pub(super) async fn test<Setup: super::ConnectorSetup>(
         setup: Setup,
         command: super::TestCommand,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -592,7 +592,7 @@ mod ndc_test_commands {
         Ok(())
     }
 
-    pub async fn replay<Setup: super::ConnectorSetup>(
+    pub(super) async fn replay<Setup: super::ConnectorSetup>(
         setup: Setup,
         command: super::ReplayCommand,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -612,7 +612,7 @@ mod ndc_test_commands {
         Ok(())
     }
 
-    pub async fn bench<Setup: ConnectorSetup>(
+    pub(super) async fn bench<Setup: ConnectorSetup>(
         setup: Setup,
         command: BenchCommand,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {


### PR DESCRIPTION
Updates ndc-spec and adds a bench subcommand for simple benchmarks of connectors built with the SDK:

```
Usage: ndc_hub_example bench [OPTIONS] --configuration <DIRECTORY> --snapshots-dir <DIRECTORY>

Options:
      --configuration <DIRECTORY>  [env: HASURA_CONFIGURATION_DIRECTORY=]
      --samples <COUNT>            the number of samples to collect per test [default: 100]
      --tolerance <TOLERANCE>      tolerable deviation from previous report, in standard deviations from the mean
      --snapshots-dir <DIRECTORY>  [env: HASURA_SNAPSHOTS_DIR=]
  -h, --help                       Print help
```