### PR TITLE
Add a  specific error variant for missing configuration files

### DIFF
--- a/rust-connector-sdk/src/connector.rs
+++ b/rust-connector-sdk/src/connector.rs
@@ -21,6 +21,8 @@ pub enum ParseError {
     ParseError(LocatedError),
     #[error("error validating configuration: {0}")]
     ValidateError(InvalidNodes),
+    #[error("could not find configuration file: {0}")]
+    CouldNotFindConfiguration(PathBuf),
     #[error("error processing configuration: {0}")]
     IoError(#[from] std::io::Error),
     #[error("error processing configuration: {0}")]


### PR DESCRIPTION
I experienced a very unhelpful error when I pointed to a configuration directory that _didn't_ contain a `configuration.json`. I'd like to add an error variant for this, and then use this variant in `ndc-postgres` when we update its version of `ndc-sdk`.