### PR TITLE
Set up a Nix build.

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,8 +1,56 @@
-name: test Nix support
+name: Nix
 
 on: push
 
 jobs:
+  nix-build:
+    name: nix build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Install Nix ❄
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Run the Magic Nix Cache 🔌
+        uses: DeterminateSystems/magic-nix-cache-action@v3
+
+      - name: Build the package
+        run: nix build
+
+  nix-flake-check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Install Nix ❄
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Run the Magic Nix Cache 🔌
+        uses: DeterminateSystems/magic-nix-cache-action@v3
+
+      - name: Check the flake for errors
+        run: nix flake check
+
+  nix-fmt:
+    name: nix fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Install Nix ❄
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Run the Magic Nix Cache 🔌
+        uses: DeterminateSystems/magic-nix-cache-action@v3
+
+      - name: Check the formatting
+        run: nix fmt -- --check .
+
   evaluate-nix-shell:
     name: Evaluate the Nix shell
     runs-on: ubuntu-latest
@@ -11,10 +59,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v4
+        uses: DeterminateSystems/nix-installer-action@v9
 
       - name: Run the Magic Nix Cache 🔌
-        uses: DeterminateSystems/magic-nix-cache-action@v2
+        uses: DeterminateSystems/magic-nix-cache-action@v3
 
       - name: Evaluate the Nix shell
         run: nix develop -c "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Rust
 /target
 
+# Nix
+/result
+/result-*
+
 # direnv
 /.direnv
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
 resolver = "2"
+
+package.version = "0.1.0"
+package.edition = "2021"
+package.license = "Apache-2.0"
+
 members = [
   "rust-connector-sdk",
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,35 @@
 {
   "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710003968,
+        "narHash": "sha256-g8+K+mLiNG5uch35Oy9oDQBAmGSkCcqrd0Jjme7xiG0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "10484f86201bb94bd61ecc5335b1496794fedb78",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694430955,
-        "narHash": "sha256-01IHejnGTdivgQoXTh/fS740JsbOTuCtJkgTyQ+Buq8=",
+        "lastModified": 1710151613,
+        "narHash": "sha256-7FhFufw9AFhKbALjLn2r7rpvg0z0Bjd5B/FeGdju6BM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bce7373adb44a76912a03548c4d31bf6f368f21b",
+        "rev": "245f9f2bc9deaef2248caa52ac126444ef03f810",
         "type": "github"
       },
       "original": {
@@ -36,8 +56,33 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710123130,
+        "narHash": "sha256-EoGL/WSM1M2L099Q91mPKO/FRV2iu2ZLOEp3y5sLfiE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "73aca260afe5d41d3ebce932c8d896399c9d5174",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/justfile
+++ b/justfile
@@ -15,9 +15,11 @@ dev:
 
 format:
   cargo fmt --all
+  ! command -v nix > /dev/null || nix fmt
 
 format-check:
   cargo fmt --all --check
+  ! command -v nix > /dev/null || nix fmt -- --check .
 
 lint:
   cargo clippy --all-targets --all-features

--- a/rust-connector-sdk/Cargo.toml
+++ b/rust-connector-sdk/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "ndc-sdk"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "ndc_sdk"


### PR DESCRIPTION
This ensures the Nix shell uses the same Rust toolchain as `rustup`, and ensures we can build the package both with and without Nix.