### PR TITLE
Allow the operator to set the listening host IP address.

### DIFF
--- a/rust-connector-sdk/src/default_main.rs
+++ b/rust-connector-sdk/src/default_main.rs
@@ -58,6 +58,13 @@ struct ServeCommand {
     otlp_endpoint: Option<String>,
     #[arg(
         long,
+        value_name = "HOST IP",
+        env = "HASURA_CONNECTOR_HOST",
+        default_value_t = net::IpAddr::V4(net::Ipv4Addr::UNSPECIFIED),
+    )]
+    host: net::IpAddr,
+    #[arg(
+        long,
         value_name = "PORT",
         env = "HASURA_CONNECTOR_PORT",
         default_value_t = 8080
@@ -67,8 +74,6 @@ struct ServeCommand {
     service_token_secret: Option<String>,
     #[arg(long, value_name = "NAME", env = "OTEL_SERVICE_NAME")]
     service_name: Option<String>,
-    #[arg(long, env = "HASURA_ENABLE_V2_COMPATIBILITY")]
-    enable_v2_compatibility: bool,
 }
 
 #[derive(Clone, Parser)]
@@ -233,11 +238,8 @@ where
         serve_command.service_token_secret.clone(),
     );
 
-    let port = serve_command.port;
-    let address = net::SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::UNSPECIFIED), port);
-
+    let address = net::SocketAddr::new(serve_command.host, serve_command.port);
     println!("Starting server on {}", address);
-
     axum::Server::bind(&address)
         .serve(router.into_make_service())
         .with_graceful_shutdown(async {


### PR DESCRIPTION
This is often useful for security reasons, e.g. only listening on localhost or an internal IP when the service is to be proxied.

It is also useful in testing on macOS, as running the service bound to a localhost IP (`127.0.0.1` or `::1`) means that the firewall will not be alerted, and so the test will not trigger an allow/deny prompt.