### PR TITLE
Specify ndc-models version for each postgres release

### DIFF
--- a/registry/aurora/metadata.json
+++ b/registry/aurora/metadata.json
@@ -23,31 +23,37 @@
       {
         "tag": "v0.5.2",
         "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/citus/metadata.json
+++ b/registry/citus/metadata.json
@@ -23,31 +23,37 @@
       {
         "tag": "v0.5.2",
         "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/cockroach/metadata.json
+++ b/registry/cockroach/metadata.json
@@ -23,31 +23,37 @@
       {
         "tag": "v0.5.2",
         "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/neon/metadata.json
+++ b/registry/neon/metadata.json
@@ -23,31 +23,37 @@
       {
         "tag": "v0.5.2",
         "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/postgres-alloydb/metadata.json
+++ b/registry/postgres-alloydb/metadata.json
@@ -21,33 +21,39 @@
     "repository": "https://github.com/hasura/ndc-postgres",
     "version": [
       {
-        "tag": "v0.5.1",
-        "hash": "bdb2702",
+        "tag": "v0.5.2",
+        "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/postgres-azure/metadata.json
+++ b/registry/postgres-azure/metadata.json
@@ -21,33 +21,39 @@
     "repository": "https://github.com/hasura/ndc-postgres",
     "version": [
       {
-        "tag": "v0.5.1",
-        "hash": "bdb2702",
+        "tag": "v0.5.2",
+        "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/postgres-cosmos/metadata.json
+++ b/registry/postgres-cosmos/metadata.json
@@ -21,33 +21,39 @@
     "repository": "https://github.com/hasura/ndc-postgres",
     "version": [
       {
-        "tag": "v0.5.1",
-        "hash": "bdb2702",
+        "tag": "v0.5.2",
+        "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/postgres-gcp/metadata.json
+++ b/registry/postgres-gcp/metadata.json
@@ -21,33 +21,39 @@
     "repository": "https://github.com/hasura/ndc-postgres",
     "version": [
       {
-        "tag": "v0.5.1",
-        "hash": "bdb2702",
+        "tag": "v0.5.2",
+        "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/postgres-timescaledb/metadata.json
+++ b/registry/postgres-timescaledb/metadata.json
@@ -21,33 +21,39 @@
     "repository": "https://github.com/hasura/ndc-postgres",
     "version": [
       {
-        "tag": "v0.5.1",
-        "hash": "bdb2702",
+        "tag": "v0.5.2",
+        "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/postgres/metadata.json
+++ b/registry/postgres/metadata.json
@@ -23,31 +23,37 @@
       {
         "tag": "v0.5.2",
         "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
         "is_verified": true
       },
       {
         "tag": "v0.6.0",
         "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.0",
         "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
         "is_verified": true
       },
       {
         "tag": "v0.7.1",
         "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v0.8.0",
         "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
         "is_verified": true
       },
       {
         "tag": "v1.0.0",
         "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]

--- a/registry/yugabyte/metadata.json
+++ b/registry/yugabyte/metadata.json
@@ -23,6 +23,37 @@
       {
         "tag": "v0.5.2",
         "hash": "805bc53",
+        "ndc_spec_version": "0.1.1",
+        "is_verified": true
+      },
+      {
+        "tag": "v0.6.0",
+        "hash": "582c771",
+        "ndc_spec_version": "0.1.2",
+        "is_verified": true
+      },
+      {
+        "tag": "v0.7.0",
+        "hash": "0c6fbadcaceb08791fe98f3e68294c739decfbec",
+        "ndc_spec_version": "0.1.2",
+        "is_verified": true
+      },
+      {
+        "tag": "v0.7.1",
+        "hash": "53565d6b4d342f98eed5cb2a91bebac745aa1d13",
+        "ndc_spec_version": "0.1.4",
+        "is_verified": true
+      },
+      {
+        "tag": "v0.8.0",
+        "hash": "4513112",
+        "ndc_spec_version": "0.1.4",
+        "is_verified": true
+      },
+      {
+        "tag": "v1.0.0",
+        "hash": "4af168d",
+        "ndc_spec_version": "0.1.5",
         "is_verified": true
       }
     ]


### PR DESCRIPTION
We'd like to include the `ndc_models` version requested by a user as an env var, so we are using this as a mapping between desired connector version and underlying `ndc_models` version.

A few of the Postgres variants were out of line, I just fixed one and copy pasted so they should all match now.