### PR TITLE
Update duckdb connector to v0.0.22

### DIFF
--- a/registry/hasura/duckdb/metadata.json
+++ b/registry/hasura/duckdb/metadata.json
@@ -1,43 +1,35 @@
 {
-    "overview": {
-      "namespace": "hasura",
-      "description": "Connect to a DuckDB database and expose them to Hasura v3 Project",
-      "title": "(MotherDuck) DuckDB Native Data Connector",
-      "logo": "logo.svg",
-      "tags": [
-        "database"
-      ],
-      "latest_version": "v0.0.17"
-    },
-    "author": {
-      "support_email": "support@hasura.io",
-      "homepage": "https://hasura.io",
-      "name": "Hasura"
-    },
-    "is_verified": false,
-    "is_hosted_by_hasura": true,
-    "packages": [
-      {
-        "version": "0.0.17",
-        "uri": "https://github.com/hasura/ndc-duckdb/releases/download/v0.0.17/connector-definition.tgz",
-        "checksum": {
-          "type": "sha256",
-          "value": "3449766fff1794f0866f19505355b37d151d91682e1f784aef664b91abd57570"
-        },
-        "source": {
-          "hash": "875c5fb4539febea0e5dad569fd8b64557870c1c"
-        }
-      }
+  "overview": {
+    "namespace": "hasura",
+    "description": "Connect to a DuckDB database and expose them to Hasura v3 Project",
+    "title": "(MotherDuck) DuckDB Native Data Connector",
+    "logo": "logo.svg",
+    "tags": [
+      "database"
     ],
-    "source_code": {
-      "is_open_source": true,
-      "repository": "https://github.com/hasura/ndc-duckdb",
-      "version": [
-        {
-          "tag": "v0.0.17",
-          "hash": "875c5fb4539febea0e5dad569fd8b64557870c1c",
-          "is_verified": false
-        }
-      ]
-    }
+    "latest_version": "v0.0.22"
+  },
+  "author": {
+    "support_email": "support@hasura.io",
+    "homepage": "https://hasura.io",
+    "name": "Hasura"
+  },
+  "is_verified": false,
+  "is_hosted_by_hasura": true,
+  "source_code": {
+    "is_open_source": true,
+    "repository": "https://github.com/hasura/ndc-duckdb",
+    "version": [
+      {
+        "tag": "v0.0.17",
+        "hash": "875c5fb4539febea0e5dad569fd8b64557870c1c",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.0.22",
+        "hash": "9eeba8eba101a44cb218cc71a3a356f3495770fe",
+        "is_verified": false
+      }
+    ]
   }
+}

--- a/registry/hasura/duckdb/releases/v0.0.22/connector-packaging.json
+++ b/registry/hasura/duckdb/releases/v0.0.22/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.22",
+  "uri": "https://github.com/hasura/ndc-duckdb/releases/download/v0.0.22/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "cf1b5146762ecc700b7e2c1d9bde71cd1b39767b657f6aa696aa5eaa16a7f566"
+  },
+  "source": {
+    "hash": "9eeba8eba101a44cb218cc71a3a356f3495770fe"
+  }
+}


### PR DESCRIPTION
This PR updates the duckdb connector metadata to version 0.0.22.