### PR TITLE
copy connector-packaging.json for pg variants

### DIFF
--- a/registry/hasura/aurora/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/aurora/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}

--- a/registry/hasura/citus/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/citus/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}

--- a/registry/hasura/cockroach/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/cockroach/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}

--- a/registry/hasura/neon/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/neon/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}

--- a/registry/hasura/postgres-alloydb/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/postgres-alloydb/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}

--- a/registry/hasura/postgres-azure/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/postgres-azure/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}

--- a/registry/hasura/postgres-cosmos/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/postgres-cosmos/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}

--- a/registry/hasura/postgres-gcp/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/postgres-gcp/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}

--- a/registry/hasura/postgres-timescaledb/releases/v1.1.0/connector-packaging.json
+++ b/registry/hasura/postgres-timescaledb/releases/v1.1.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.1.0",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "a5f358cea0bade28b00fa868e055a29bab158173ec8a65ec2a2d4cc9ff060d3d"
+  },
+  "source": {
+    "hash": "a57c0b5c76f98ea1da33d5aa649b6e8d071c3d4a"
+  }
+}


### PR DESCRIPTION
```sh
#!/usr/bin/env bash

for variant in \
    'aurora' \
    'citus' \
    'cockroach' \
    'neon' \
    'postgres-alloydb' \
    'postgres-azure' \
    'postgres-cosmos' \
    'postgres-gcp' \
    'postgres-timescaledb' ; do

cp -r registry/hasura/postgres/releases/v1.1.0 registry/hasura/"${variant}"/releases/v1.1.0

done
```