### PR TITLE
Allow forked PRs to deploy connector version publishing in the staging environment

### DIFF
--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -19,6 +19,26 @@ jobs:
         with:
           fetch_depth: 1
 
+
+      - name: Check for PR approvals
+        id: check-approval
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: reviews } = await github.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const approved = reviews.some(review => review.state === 'APPROVED');
+            return approved;
+
+      - name: Cancel if not approved
+        if: steps.check-approval.outputs.approved == 'false'
+        run: |
+          echo "The PR has not been approved. Cancelling the workflow."
+          exit 1  # This will exit the workflow early
+
       - name: Get all connector version package changes
         id: connector-version-changed-files
         uses: tj-actions/changed-files@v44

--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -1,7 +1,7 @@
 name: Update Hub DB from GH Registry (Staging)
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
This PR extends the `registry-updates` workflow to access the repository secrets for forked repository PRs, like this [one](https://github.com/hasura/ndc-hub/pull/257) . 

It should be noted that, we are allowing this only for the staging environment and this is not needed for the production environment.