### PR TITLE
Use the `github-script@v7` to correctly get the approval status on PR

### DIFF
--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -19,25 +19,23 @@ jobs:
         with:
           fetch_depth: 1
 
-
       - name: Check for PR approvals
         id: check-approval
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
-            const { data: reviews } = await github.pulls.listReviews({
+            const { owner, repo } = context.issue;
+            const pull_number = context.payload.pull_request.number;
+            console.log("Owner and repo and pull_number", owner, repo, pull_number);
+            const { data: reviews } = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
             });
             const approved = reviews.some(review => review.state === 'APPROVED');
-            return approved;
-
-      - name: Cancel if not approved
-        if: steps.check-approval.outputs.approved == 'false'
-        run: |
-          echo "The PR has not been approved. Cancelling the workflow."
-          exit 1  # This will exit the workflow early
+            if (!approved) {
+              core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
+            }
 
       - name: Get all connector version package changes
         id: connector-version-changed-files


### PR DESCRIPTION
This PR fixes the logic of checking the approval status on the PR and uses the `github-script@v7` to do the same. 