### PR TITLE
Fix bug in registry update automation

### DIFF
--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -24,23 +24,23 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch_depth: 1
 
-      - name: Check for PR approvals
-        id: check-approval
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.issue;
-            const pull_number = context.payload.pull_request.number;
-            console.log("Owner and repo and pull_number", owner, repo, pull_number);
-            const { data: reviews } = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-            const approved = reviews.some(review => review.state === 'APPROVED');
-            if (!approved) {
-              core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
-            }
+      # - name: Check for PR approvals
+      #   id: check-approval
+      #   uses: actions/github-script@v7
+      #   with:
+      #     script: |
+      #       const { owner, repo } = context.issue;
+      #       const pull_number = context.payload.pull_request.number;
+      #       console.log("Owner and repo and pull_number", owner, repo, pull_number);
+      #       const { data: reviews } = await github.rest.pulls.listReviews({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         pull_number: context.payload.pull_request.number,
+      #       });
+      #       const approved = reviews.some(review => review.state === 'APPROVED');
+      #       if (!approved) {
+      #         core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
+      #       }
 
       - name: Get all connector version package changes
         id: connector-version-changed-files

--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -24,23 +24,23 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 1
 
-      # - name: Check for PR approvals
-      #   id: check-approval
-      #   uses: actions/github-script@v7
-      #   with:
-      #     script: |
-      #       const { owner, repo } = context.issue;
-      #       const pull_number = context.payload.pull_request.number;
-      #       console.log("Owner and repo and pull_number", owner, repo, pull_number);
-      #       const { data: reviews } = await github.rest.pulls.listReviews({
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         pull_number: context.payload.pull_request.number,
-      #       });
-      #       const approved = reviews.some(review => review.state === 'APPROVED');
-      #       if (!approved) {
-      #         core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
-      #       }
+      - name: Check for PR approvals
+        id: check-approval
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.issue;
+            const pull_number = context.payload.pull_request.number;
+            console.log("Owner and repo and pull_number", owner, repo, pull_number);
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const approved = reviews.some(review => review.state === 'APPROVED');
+            if (!approved) {
+              core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
+            }
 
       - name: Get all connector version package changes
         id: connector-version-changed-files

--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -24,23 +24,23 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 1
 
-      - name: Check for PR approvals
-        id: check-approval
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.issue;
-            const pull_number = context.payload.pull_request.number;
-            console.log("Owner and repo and pull_number", owner, repo, pull_number);
-            const { data: reviews } = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-            const approved = reviews.some(review => review.state === 'APPROVED');
-            if (!approved) {
-              core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
-            }
+      # - name: Check for PR approvals
+      #   id: check-approval
+      #   uses: actions/github-script@v7
+      #   with:
+      #     script: |
+      #       const { owner, repo } = context.issue;
+      #       const pull_number = context.payload.pull_request.number;
+      #       console.log("Owner and repo and pull_number", owner, repo, pull_number);
+      #       const { data: reviews } = await github.rest.pulls.listReviews({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         pull_number: context.payload.pull_request.number,
+      #       });
+      #       const approved = reviews.some(review => review.state === 'APPROVED');
+      #       if (!approved) {
+      #         core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
+      #       }
 
       - name: Get all connector version package changes
         id: connector-version-changed-files

--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   update_registry_db:
     runs-on: ubuntu-latest
-    environment: test
+    environment: staging
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - main
+      - kc/run-workflow-on-forked-prs
     types: [opened, synchronize, reopened]
     paths:
       - registry/**
@@ -11,7 +12,7 @@ on:
 jobs:
   update_registry_db:
     runs-on: ubuntu-latest
-    environment: staging
+    environment: test
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -22,7 +22,7 @@ jobs:
           # be checked out.
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-          fetch_depth: 1
+          fetch-depth: 1
 
       # - name: Check for PR approvals
       #   id: check-approval

--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     branches:
       - main
-      - kc/run-workflow-on-forked-prs
     types: [opened, synchronize, reopened]
     paths:
       - registry/**
@@ -24,23 +23,23 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 1
 
-      # - name: Check for PR approvals
-      #   id: check-approval
-      #   uses: actions/github-script@v7
-      #   with:
-      #     script: |
-      #       const { owner, repo } = context.issue;
-      #       const pull_number = context.payload.pull_request.number;
-      #       console.log("Owner and repo and pull_number", owner, repo, pull_number);
-      #       const { data: reviews } = await github.rest.pulls.listReviews({
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         pull_number: context.payload.pull_request.number,
-      #       });
-      #       const approved = reviews.some(review => review.state === 'APPROVED');
-      #       if (!approved) {
-      #         core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
-      #       }
+      - name: Check for PR approvals
+        id: check-approval
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.issue;
+            const pull_number = context.payload.pull_request.number;
+            console.log("Owner and repo and pull_number", owner, repo, pull_number);
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const approved = reviews.some(review => review.state === 'APPROVED');
+            if (!approved) {
+              core.setFailed('This workflow will only run when the PR is approved by someone in Hasura')
+            }
 
       - name: Get all connector version package changes
         id: connector-version-changed-files

--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
+          # In the case of forked PRs, the forked repository will
+          # be checked out.
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch_depth: 1
 
       - name: Check for PR approvals


### PR DESCRIPTION
This PR modifies the check out logic a bit for PRs opened on forked repositories. 
If the PR opened is from a forked repository, the code will be checked out to that repo's `ref` commit to access the files present in that branch, in the case the PR is opened directly in this repo, the behaviour will be the same as it was earlier.