### PR TITLE
Update terminology in the Postgres README

### DIFF
--- a/registry/hasura/postgres/README.md
+++ b/registry/hasura/postgres/README.md
@@ -12,7 +12,7 @@ for more information about specific features that are available for the PostgreS
 
 ## Deployment
 
-The connector is hosted by Hasura and can be used from the [Hasura v3 Console](https://console.hasura.io).
+The connector is hosted by Hasura and can be used from the [Hasura DDN Console](https://console.hasura.io).
 
 ## Usage
 


### PR DESCRIPTION
The V3 console is now called the DDN console.