### PR TITLE
hasura/qdrant: add missing releases

### DIFF
--- a/registry/hasura/qdrant/releases/v0.1.7/connector-packaging.json
+++ b/registry/hasura/qdrant/releases/v0.1.7/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.1.7",
+  "uri": "https://github.com/hasura/ndc-qdrant/releases/download/v0.1.7/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "6ed4b6252e9f3f91d68deb4195a11b70fe14691b155af792ec91f8aee743b587"
+  },
+  "source": {
+    "hash": "848a9022df832b4595473f8bae4b3a66564f0bda"
+  }
+}

--- a/registry/hasura/qdrant/releases/v0.1.9/connector-packaging.json
+++ b/registry/hasura/qdrant/releases/v0.1.9/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.1.9",
+  "uri": "https://github.com/hasura/ndc-qdrant/releases/download/v0.1.9/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "38a83f9851a6600e23eeda5e2c07f2aba492b6298a7a0c434a70af9d143ec4f4"
+  },
+  "source": {
+    "hash": "c07dbcfbf00a1c4549eaf2860afad018910c830a"
+  }
+}


### PR DESCRIPTION
We would like ndc-hub to be the one source of truth for all connector-related information. Adding these missing connector packaging files for realizing that goal.