### PR TITLE
Release Postgres 1.1.2

### DIFF
--- a/registry/hasura/postgres/metadata.json
+++ b/registry/hasura/postgres/metadata.json
@@ -69,6 +69,11 @@
         "tag": "v1.1.1",
         "hash": "fc6a7a7",
         "is_verified": true
+      },
+      {
+        "tag": "v1.1.2",
+        "hash": "3ecf2be",
+        "is_verified": true
       }
     ]
   }

--- a/registry/hasura/postgres/releases/v1.1.2/connector-packaging.json
+++ b/registry/hasura/postgres/releases/v1.1.2/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v1.1.2",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/v1.1.2/package.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "894fdf318777b596b320060408b86b84e520413786482f423cc82189530e21a3"
+  },
+  "source": {
+    "hash": "3ecf2bec20b5f4e70c006efc5d00ed2a59f4a282"
+  }
+}


### PR DESCRIPTION
Note: this uses a `v` prefix in the `version` field of the `connector-packaging.json` file.

This is most likely incorrect, but consistent with previous releases. We may fix this later.