### PR TITLE
rfc: update semver to have version prefix

### DIFF
--- a/rfcs/0006-connector-publishing-automation.md
+++ b/rfcs/0006-connector-publishing-automation.md
@@ -59,7 +59,7 @@ file should contain the relevant information to access the package definition.
 
 ```json
 {
-    "version": "0.0.1",
+    "version": "v0.0.1",
     "uri": "https://github.com/hasura/ndc-mongodb/releases/download/v0.0.1/connector-definition.tgz",
     "checksum": {
         "type": "sha256",


### PR DESCRIPTION
We would like our versions to have the `v` prefix to avoid discrepancies with the other places. We did one round of cleanups already in the existing connector configurations. We will be soon introducing a CI check that performs this validation in pull requests.