### PR TITLE
ci: update ddn-assets version to v0.2.0

### DIFF
--- a/.github/workflows/ddn-assets.yaml
+++ b/.github/workflows/ddn-assets.yaml
@@ -4,11 +4,12 @@ on:
   push:
     branches:
       - "main"
+      - "vishnu/cps-861-store-cli-plugin-binaries-in-asset-store"
 
 env:
   DATA_TAG: data.${{ github.sha }}
   DATA_SERVER_TAG: data-server.${{ github.sha }}
-  DDN_ASSETS_VERSION: v0.1.0
+  DDN_ASSETS_VERSION: v0.2.0
 
 jobs:
   generate:
@@ -33,6 +34,8 @@ jobs:
         run: |
           export NDC_HUB_GIT_REPO_FILE_PATH=$PWD
           echo "NDC_HUB_GIT_REPO_FILE_PATH = $NDC_HUB_GIT_REPO_FILE_PATH"
+          export CONN_HUB_DATA_SERVER_URL="https://storage.googleapis.com/staging-connector-platform-registry/assets"
+          echo "CONN_HUB_DATA_SERVER_URL = $CONN_HUB_DATA_SERVER_URL"
 
           pushd docker/data
             echo "Downloading ddn-assets"

--- a/.github/workflows/ddn-assets.yaml
+++ b/.github/workflows/ddn-assets.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "vishnu/cps-861-store-cli-plugin-binaries-in-asset-store"
 
 env:
   DATA_TAG: data.${{ github.sha }}

--- a/docker/data/Dockerfile
+++ b/docker/data/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
 
-COPY assets /assets
+COPY assets/outputs /assets


### PR DESCRIPTION
Verified by
- triggering CI here: https://github.com/hasura/ndc-hub/actions/runs/11688699757/job/32549748749
- Running `docker run --rm -it -P ghcr.io/hasura/ndc-hub:data-server.5fd08ca16ddd05b8a73547ffba0bd533ce849917` and visiting the site exposed by it. It seem to have the right artifacts.