### PR TITLE
ci: update ddn-assets version to v0.2.1

### DIFF
--- a/.github/workflows/ddn-assets.yaml
+++ b/.github/workflows/ddn-assets.yaml
@@ -8,7 +8,7 @@ on:
 env:
   DATA_TAG: data.${{ github.sha }}
   DATA_SERVER_TAG: data-server.${{ github.sha }}
-  DDN_ASSETS_VERSION: v0.2.0
+  DDN_ASSETS_VERSION: v0.2.1
 
 jobs:
   generate:


### PR DESCRIPTION
Refer https://github.com/hasura/ddn-assets/releases/tag/v0.2.1 for more details.