### PR TITLE
Release HTTP connector v0.8.1

### DIFF
--- a/registry/hasura/http/metadata.json
+++ b/registry/hasura/http/metadata.json
@@ -5,7 +5,7 @@
     "title": "HTTP Connector",
     "logo": "logo.png",
     "tags": ["http", "rest", "api", "openapi"],
-    "latest_version": "v0.7.0"
+    "latest_version": "v0.8.1"
   },
   "author": {
     "support_email": "support@hasura.io",

--- a/registry/hasura/http/releases/v0.8.1/connector-packaging.json
+++ b/registry/hasura/http/releases/v0.8.1/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.8.1",
+  "uri": "https://github.com/hasura/ndc-http/releases/download/v0.8.1/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "180aecffdb1bcfe21762fd572294cbcae6553d401da4a3259ac65782ac865ca7"
+  },
+  "source": {
+    "hash": "50fc4dd56ee04f8cd3a91a973567324a805790d5"
+  }
+}


### PR DESCRIPTION
[Changlog](https://github.com/hasura/ndc-http/releases/tag/v0.8.1)