### PR TITLE
Release Go connector v1.7.0

### DIFF
--- a/registry/hasura/go/metadata.json
+++ b/registry/hasura/go/metadata.json
@@ -5,7 +5,7 @@
     "title": "Go Connector",
     "logo": "logo.svg",
     "tags": [],
-    "latest_version": "v1.6.3"
+    "latest_version": "v1.7.0"
   },
   "author": {
     "support_email": "support@hasura.io",
@@ -16,68 +16,6 @@
   "is_hosted_by_hasura": false,
   "source_code": {
     "is_open_source": true,
-    "repository": "https://github.com/hasura/ndc-sdk-go",
-    "version": [
-      {
-        "tag": "v1.6.3",
-        "hash": "5b686507c3f1ac826838a8963ed2c2b9279e640f",
-        "is_verified": true
-      },
-      {
-        "tag": "v1.6.2",
-        "hash": "0310e6ba02d8cbb00e89dac06f9a46e78037d875",
-        "is_verified": true
-      },
-      {
-        "tag": "v1.6.0",
-        "hash": "3b6d7ce67d86dfef6c776caa1b56772ad82e44a1",
-        "is_verified": true
-      },
-      {
-        "tag": "v1.5.1",
-        "hash": "e6a7fd89d13f0a8b12732ee88ae5bbe775ec60ba",
-        "is_verified": true
-      },
-      {
-        "tag": "v1.4.0",
-        "hash": "c31575e0eb0c55e0f326c859f7c1a830dc09c424",
-        "is_verified": true
-      },
-      {
-        "tag": "v1.3.1",
-        "hash": "f6093ca96fe64063df786159a2bb061c01d9197d",
-        "is_verified": true
-      },
-      {
-        "tag": "v1.2.3",
-        "hash": "1fdc72d31dccae129d6d626dea6e31b5cd3b0b18",
-        "is_verified": true
-      },
-      {
-        "tag": "v1.1.2",
-        "hash": "32e28e549f11b790c320b6a79ad33ad8e6df5bd7",
-        "is_verified": true
-      },
-      {
-        "tag": "v1.0.0",
-        "hash": "42259e9a9c719131721f0058c552e9b8a4a36973",
-        "is_verified": true
-      },
-      {
-        "tag": "v0.6.3",
-        "hash": "726b3fbb442fae62d18840905545f1d663baf87b",
-        "is_verified": true
-      },
-      {
-        "tag": "v0.5.2",
-        "hash": "79788195359a5e3cf0fc8896b61eb8f4d9196427",
-        "is_verified": true
-      },
-      {
-        "tag": "v0.4.0",
-        "hash": "ac27498b6dbd5e803ca97e0fc702f52e2d9b429d",
-        "is_verified": true
-      }
-    ]
+    "repository": "https://github.com/hasura/ndc-sdk-go"
   }
 }

--- a/registry/hasura/go/releases/v1.7.0/connector-packaging.json
+++ b/registry/hasura/go/releases/v1.7.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v1.7.0",
+  "uri": "https://github.com/hasura/ndc-sdk-go/releases/download/v1.7.0/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "f5716d9618d27552d5a34112b3814734d17ff0106dcc4f12e7605ed2e282c765"
+  },
+  "source": {
+    "hash": "6486aa7cf45131d28428e9b97c8b81853c47af91"
+  }
+}


### PR DESCRIPTION
[Changelog](https://github.com/hasura/ndc-sdk-go/releases/tag/v1.7.0)