### PR TITLE
Update duckdb connector to v0.1.4

### DIFF
--- a/registry/hasura/duckdb/metadata.json
+++ b/registry/hasura/duckdb/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v0.1.3"
+    "latest_version": "v0.1.4"
   },
   "author": {
     "support_email": "Community Supported",
@@ -38,6 +38,11 @@
       {
         "tag": "v0.1.3",
         "hash": "77ee12cef21cd4231c3f6a6433d9249da180e59e",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.4",
+        "hash": "f9a04ce7a9b30c26f0141bbe23a4d2ee1a3e0d00",
         "is_verified": false
       }
     ]

--- a/registry/hasura/duckdb/releases/v0.1.4/connector-packaging.json
+++ b/registry/hasura/duckdb/releases/v0.1.4/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.1.4",
+  "uri": "https://github.com/hasura/ndc-duckdb/releases/download/v0.1.4/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "dc238b7180da416f1a51dabf1ecb42fe5e2f7e99e47cfe5eeddf13c7bcaf646b"
+  },
+  "source": {
+    "hash": "f9a04ce7a9b30c26f0141bbe23a4d2ee1a3e0d00"
+  }
+}


### PR DESCRIPTION
This PR updates the duckdb connector metadata to version 0.1.4.