### PR TITLE
Update duckdb connector to v0.1.5

### DIFF
--- a/registry/hasura/duckdb/metadata.json
+++ b/registry/hasura/duckdb/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v0.1.4"
+    "latest_version": "v0.1.5"
   },
   "author": {
     "support_email": "Community Supported",
@@ -43,6 +43,11 @@
       {
         "tag": "v0.1.4",
         "hash": "f9a04ce7a9b30c26f0141bbe23a4d2ee1a3e0d00",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.5",
+        "hash": "52629bd75763c850d9f283da1507f987dd993930",
         "is_verified": false
       }
     ]

--- a/registry/hasura/duckdb/releases/v0.1.5/connector-packaging.json
+++ b/registry/hasura/duckdb/releases/v0.1.5/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.1.5",
+  "uri": "https://github.com/hasura/ndc-duckdb/releases/download/v0.1.5/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "bde0e2aa49b41cb93f7d6b77dbb86ba3039de5c95859430447889ef91fd2e88f"
+  },
+  "source": {
+    "hash": "52629bd75763c850d9f283da1507f987dd993930"
+  }
+}


### PR DESCRIPTION
This PR updates the duckdb connector metadata to version 0.1.5.