### PR TITLE
Update duckdb connector to v0.1.6

### DIFF
--- a/registry/hasura/duckdb/metadata.json
+++ b/registry/hasura/duckdb/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v0.1.4"
+    "latest_version": "v0.1.6"
   },
   "author": {
     "support_email": "Community Supported",
@@ -43,6 +43,11 @@
       {
         "tag": "v0.1.4",
         "hash": "f9a04ce7a9b30c26f0141bbe23a4d2ee1a3e0d00",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.6",
+        "hash": "de643e53e39db87c7cb7a60678031a753b39a50f",
         "is_verified": false
       }
     ]

--- a/registry/hasura/duckdb/releases/v0.1.6/connector-packaging.json
+++ b/registry/hasura/duckdb/releases/v0.1.6/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.1.6",
+  "uri": "https://github.com/hasura/ndc-duckdb/releases/download/v0.1.6/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "93758097c4c61da1e6b8ecd1af05f901f308fc2482c0bb25677c8d57d7423e93"
+  },
+  "source": {
+    "hash": "de643e53e39db87c7cb7a60678031a753b39a50f"
+  }
+}


### PR DESCRIPTION
This PR updates the duckdb connector metadata to version 0.1.6.