### PR TITLE
Update duckdb connector to v0.1.7

### DIFF
--- a/registry/hasura/duckdb/metadata.json
+++ b/registry/hasura/duckdb/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v0.1.6"
+    "latest_version": "v0.1.7"
   },
   "author": {
     "support_email": "Community Supported",
@@ -48,6 +48,11 @@
       {
         "tag": "v0.1.6",
         "hash": "de643e53e39db87c7cb7a60678031a753b39a50f",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.7",
+        "hash": "dbc3b2b5332d4e2d3549a33a3cfc38c4ead09e8e",
         "is_verified": false
       }
     ]

--- a/registry/hasura/duckdb/releases/v0.1.7/connector-packaging.json
+++ b/registry/hasura/duckdb/releases/v0.1.7/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.1.7",
+  "uri": "https://github.com/hasura/ndc-duckdb/releases/download/v0.1.7/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "435d5bfa0a9cda950b23124ae04db90f2d0e0e012292ae271d053be74cc20886"
+  },
+  "source": {
+    "hash": "dbc3b2b5332d4e2d3549a33a3cfc38c4ead09e8e"
+  }
+}


### PR DESCRIPTION
This PR updates the duckdb connector metadata to version 0.1.7.