### PR TITLE
Update duckdb connector to v0.1.8

### DIFF
--- a/registry/hasura/duckdb/metadata.json
+++ b/registry/hasura/duckdb/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v0.1.6"
+    "latest_version": "v0.1.8"
   },
   "author": {
     "support_email": "Community Supported",
@@ -48,6 +48,11 @@
       {
         "tag": "v0.1.6",
         "hash": "de643e53e39db87c7cb7a60678031a753b39a50f",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.8",
+        "hash": "a3b5887fdbdee7160e943af2731231a7d986e22a",
         "is_verified": false
       }
     ]

--- a/registry/hasura/duckdb/releases/v0.1.8/connector-packaging.json
+++ b/registry/hasura/duckdb/releases/v0.1.8/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.1.8",
+  "uri": "https://github.com/hasura/ndc-duckdb/releases/download/v0.1.8/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "9dcca01971c634a9205f13b2f686860f3b7dd250349e166d19f0f11b10470217"
+  },
+  "source": {
+    "hash": "a3b5887fdbdee7160e943af2731231a7d986e22a"
+  }
+}


### PR DESCRIPTION
This PR updates the duckdb connector metadata to version 0.1.8.