### PR TITLE
Update duckdb connector to v0.2.0

### DIFF
--- a/registry/hasura/duckdb/metadata.json
+++ b/registry/hasura/duckdb/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v0.1.6"
+    "latest_version": "v0.2.0"
   },
   "author": {
     "support_email": "Community Supported",
@@ -48,6 +48,11 @@
       {
         "tag": "v0.1.6",
         "hash": "de643e53e39db87c7cb7a60678031a753b39a50f",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.2.0",
+        "hash": "79afa4d6dd4b0056897b2c7fde5b67f91f2639f9",
         "is_verified": false
       }
     ]

--- a/registry/hasura/duckdb/releases/v0.2.0/connector-packaging.json
+++ b/registry/hasura/duckdb/releases/v0.2.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.2.0",
+  "uri": "https://github.com/hasura/ndc-duckdb/releases/download/v0.2.0/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "7371b0d9010242cecdab36517090906d7c646441a6f1296f31332b2227cceca6"
+  },
+  "source": {
+    "hash": "79afa4d6dd4b0056897b2c7fde5b67f91f2639f9"
+  }
+}


### PR DESCRIPTION
This PR updates the duckdb connector metadata to version 0.2.0.