### PR TITLE
Update ndc-python-lambda connector to v0.1.6

### DIFF
--- a/registry/hasura/python/README.md
+++ b/registry/hasura/python/README.md
@@ -1,5 +1,4 @@
 # Hasura Python Lambda Connector
-
 <a href="https://www.python.org/"><img src="https://github.com/hasura/ndc-python-lambda/blob/main/docs/logo.svg" align="right" width="200"></a>
 
 [![Docs](https://img.shields.io/badge/docs-v3.x-brightgreen.svg?style=flat)](https://hasura.io/connectors/python)
@@ -11,41 +10,92 @@ This connector allows you to write Python code and call it using Hasura!
 
 With Hasura, you can integrate -- and even host -- this business logic directly with Hasura DDN and your API.
 
-You can handle custom business logic using the Python Lambda data connector. Using this connector, you can transform or
-enrich data before it reaches your customers, or perform any other business logic you may need.
+You can handle custom business logic using the Python Lambda data connector. Using this connector, you can transform or enrich data before it reaches your customers, or perform any other business logic you may need.
 
-You can then integrate these functions as individual commands in your metadata and API. This process enables you to
-simplify client applications and speed up your backend development!
+You can then integrate these functions as individual commands in your metadata and API. This process enables you to simplify client applications and speed up your backend development!
 
-This connector is built using the [Python Data Connector SDK](https://github.com/hasura/ndc-sdk-python) and implements
-the [Data Connector Spec](https://github.com/hasura/ndc-spec).
+This connector is built using the [Python Data Connector SDK](https://github.com/hasura/ndc-sdk-python) and implements the [Data Connector Spec](https://github.com/hasura/ndc-spec).
 
-## Prerequisites
+## Before you get Started
 
-1. Create a [Hasura Cloud account](https://console.hasura.io)
-2. Please ensure you have the [DDN CLI](https://hasura.io/docs/3.0/cli/installation) and
-   [Docker](https://docs.docker.com/engine/install/) installed
-3. [Create a supergraph](https://hasura.io/docs/3.0/getting-started/init-supergraph)
-4. [Create a subgraph](https://hasura.io/docs/3.0/getting-started/init-subgraph)
+1. The [DDN CLI](https://hasura.io/docs/3.0/cli/installation) and [Docker](https://docs.docker.com/engine/install/) installed
+2. A [supergraph](https://hasura.io/docs/3.0/getting-started/init-supergraph)
+3. A [subgraph](https://hasura.io/docs/3.0/getting-started/init-subgraph)
 
-The steps below explain how to initialize and configure a connector on your local machine (typically for development
-purposes).You can learn how to deploy a connector to Hasura DDN — after it's been configured —
-[here](https://hasura.io/docs/3.0/getting-started/deployment/deploy-a-connector).
+The steps below explain how to Initialize and configure a connector for local development. You can learn how to deploy a connector — after it's been configured — [here](https://hasura.io/docs/3.0/getting-started/deployment/deploy-a-connector).
 
-## Using the Python Lambda connector
+## Using the Python connector
 
-Check out the [Hasura docs here](https://hasura.io/docs/3.0/business-logic/python#add-the-python-connector-to-a-project)
-to get started with the Python Lambda connector.
+### Step 1: Authenticate your CLI session
+
+```bash
+ddn auth login
+```
+
+### Step 2: Configure the connector
+
+Once you have an initialized supergraph and subgraph, run the initialization command in interactive mode while providing a name for the connector in the prompt:
+
+```bash
+ddn connector init python -i
+```
+
+#### Step 2.1: Choose the `hasura/python` option from the list
+
+#### Step 2.2: Choose a port for the connector
+
+The CLI will ask for a specific port to run the connector on. Choose a port that is not already in use or use the default suggested port.
+
+### Step 3: Introspect the connector
+
+Introspecting the connector will generate a `config.json` file and a `python.hml` file.
+
+```bash
+ddn connector introspect python
+```
+
+### Step 4: Add your resources
+
+You can add the models, commands, and relationships to your API by tracking them which generates the HML files. 
+
+```bash
+ddn connector-link add-resources python
+```
+
+### Step 5: Run your connector
+
+You can run your connector locally, or include it in the docker setup.
+
+#### Run the connector in Docker
+
+To include your connector in the docker setup, include its compose file at the top of your supergraph `compose.yaml` file like this:
+
+```yaml
+include:
+  - path: app/connector/python/compose.yaml
+```
+
+#### Run the connector locally
+
+To run your connector outside of Docker first go into the connector directory:
+
+`cd app/connector/python`
+
+Install the requirements:
+
+`pip3 install -r requirements.txt`
+
+Then run the connector locally:
+
+```ddn connector setenv --connector connector.yaml -- python3 functions.py serve```
 
 ## Documentation
 
-View the full documentation for the Python Lambda connector
-[here](https://github.com/hasura/ndc-python-lambda/blob/main/docs/index.md).
+View the full documentation for the Python Lambda connector [here](https://github.com/hasura/ndc-python-lambda/blob/main/docs/index.md).
 
 ## Contributing
 
-Check out our [contributing guide](https://github.com/hasura/ndc-python-lambda/blob/main/docs/contributing.md) for more
-details.
+Check out our [contributing guide](https://github.com/hasura/ndc-python-lambda/blob/main/docs/contributing.md) for more details.
 
 ## License
 

--- a/registry/hasura/python/metadata.json
+++ b/registry/hasura/python/metadata.json
@@ -1,53 +1,60 @@
 {
-    "overview":{
-        "namespace":"hasura",
-        "description":"The Python Lambda Connector allows you to expose Python functions as NDC functions/procedures for use in your Hasura DDN subgraphs.",
-        "title":"Python Lambda Connector",
-        "logo":"logo.svg",
-        "tags":["lambda"],
-        "latest_version":"v0.1.4"
-    },
-    "author":{
-        "support_email":"support@hasura.io",
-        "homepage":"https://hasura.io",
-        "name":"Hasura"
-    },
-    "is_verified":false,
-    "is_hosted_by_hasura":false,
-    "source_code":{
-        "is_open_source":true,
-        "repository":"https://github.com/hasura/ndc-python-lambda",
-        "version":[
-            {
-                "tag":"v0.0.45",
-                "hash":"76a3d43d8ccf990b14812d9c0c354c4320b810f6",
-                "is_verified": false
-            },
-            {
-                "tag":"v0.1.0",
-                "hash":"6f83afe355a60bd9677536e1bb13b212dca5460a",
-                "is_verified": false
-            },
-            {
-                "tag": "v0.1.1",
-                "hash": "74267a7fa5212c9963b47a72d8dbe1e682b9c195",
-                "is_verified": false
-            },
-            {
-                "tag": "v0.1.2",
-                "hash": "6df477dd3fcb39bae481c9ef10bff09c6cee1ac9",
-                "is_verified": false
-            },
-            {
-                "tag": "v0.1.3",
-                "hash": "455f4ec34a58421efd815d5071b88c0211d4f201",
-                "is_verified": false
-            },
-            {
-                "tag": "v0.1.4",
-                "hash": "5bdfa301446f2aecee190d0fd9c6d9081f802109",
-                "is_verified": false
-            }
-        ]
-    }
+  "overview": {
+    "namespace": "hasura",
+    "description": "The Python Lambda Connector allows you to expose Python functions as NDC functions/procedures for use in your Hasura DDN subgraphs.",
+    "title": "Python Lambda Connector",
+    "logo": "logo.svg",
+    "tags": [
+      "lambda"
+    ],
+    "latest_version": "v0.1.6"
+  },
+  "author": {
+    "support_email": "support@hasura.io",
+    "homepage": "https://hasura.io",
+    "name": "Hasura"
+  },
+  "is_verified": false,
+  "is_hosted_by_hasura": false,
+  "source_code": {
+    "is_open_source": true,
+    "repository": "https://github.com/hasura/ndc-python-lambda",
+    "version": [
+      {
+        "tag": "v0.0.45",
+        "hash": "76a3d43d8ccf990b14812d9c0c354c4320b810f6",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.0",
+        "hash": "6f83afe355a60bd9677536e1bb13b212dca5460a",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.1",
+        "hash": "74267a7fa5212c9963b47a72d8dbe1e682b9c195",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.2",
+        "hash": "6df477dd3fcb39bae481c9ef10bff09c6cee1ac9",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.3",
+        "hash": "455f4ec34a58421efd815d5071b88c0211d4f201",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.4",
+        "hash": "5bdfa301446f2aecee190d0fd9c6d9081f802109",
+        "is_verified": false
+      },
+      {
+        "tag": "v0.1.6",
+        "hash": "8d4a064a8dc92bb5f2ffc1002db43b69cf63701c",
+        "is_verified": false
+      }
+    ]
+  }
 }

--- a/registry/hasura/python/releases/v0.1.6/connector-packaging.json
+++ b/registry/hasura/python/releases/v0.1.6/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.1.6",
+  "uri": "https://github.com/hasura/ndc-python-lambda/releases/download/v0.1.6/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "20a9cf16fd8fdfa840d5acd13ad7cb73a3552eb00168823e27c91b9c2de35116"
+  },
+  "source": {
+    "hash": "8d4a064a8dc92bb5f2ffc1002db43b69cf63701c"
+  }
+}


### PR DESCRIPTION
This PR updates the ndc-python-lambda connector metadata to version 0.1.6.