### PR TITLE
postgres: update the latest version

### DIFF
--- a/registry/hasura/postgres/metadata.json
+++ b/registry/hasura/postgres/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v1.2.0"
+    "latest_version": "v2.0.0"
   },
   "author": {
     "support_email": "support@hasura.io",


### PR DESCRIPTION
Noticed that this isn't upto date with what our current APIs return back when a `ddn connector init -i` is performed.