### PR TITLE
Release Go connector v1.8.0

### DIFF
--- a/registry/hasura/go/metadata.json
+++ b/registry/hasura/go/metadata.json
@@ -5,7 +5,7 @@
     "title": "Go Connector",
     "logo": "logo.svg",
     "tags": [],
-    "latest_version": "v1.7.0"
+    "latest_version": "v1.8.0"
   },
   "author": {
     "support_email": "support@hasura.io",

--- a/registry/hasura/go/releases/v1.8.0/connector-packaging.json
+++ b/registry/hasura/go/releases/v1.8.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v1.8.0",
+  "uri": "https://github.com/hasura/ndc-sdk-go/releases/download/v1.8.0/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "92f3fd77b9c2543bec75cf0d702b189ce9c5cebf3c2de7d973af89e5d44cce51"
+  },
+  "source": {
+    "hash": "2ac80cbb2c1e8e935c2a1aee501738806dba3c47"
+  }
+}


### PR DESCRIPTION
[Changelog](https://github.com/hasura/ndc-sdk-go/releases/tag/v1.8.0)