### PR TITLE
Use unexploited 'tj-actions/change-files' action

### DIFF
--- a/.github/workflows/registry-updates.yaml
+++ b/.github/workflows/registry-updates.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get all connector version package changes
         id: connector-version-changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
         with:
           json: true
           escape_json: false


### PR DESCRIPTION
There has been a security exploit in the `tj-actions/changed-files` github action. Apparently it's been hijacked with code that potentially could exfiltrate secrets from CI pipelines by printing them to build logs. More info: 
* https://github.com/tj-actions/changed-files/issues/2463 
* https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

I've changed the tag we're using to a specific git commit before the exploit code was added.