### PR TITLE
Add pull request template for consistent PR submissions

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,15 @@
+### What / Why / How
+
+<!-- What is this PR trying to accomplish? Why? How is it implemented? -->
+
+### Issue / Discussion Links
+
+<!-- If there's a relevant issue or discussion, on Linear, GitHub, Slack etc, reference it here. -->
+
+<!--
+Note: All features must be documented on ddn-docs.
+
+> **You MUST add ONE of these labels:**
+   - `docs-updated`
+   - `docs-not-required`
+-->


### PR DESCRIPTION
Add pull request template for consistent PR submissions and makes docs-updated or docs-not-required labels mandatory.