### PR TITLE
add vulnerability scan

### DIFF
--- a/.github/workflows/gokakashi-scan.yaml
+++ b/.github/workflows/gokakashi-scan.yaml
@@ -1,0 +1,54 @@
+name: Vulnerability Scan using Gokakashi
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/gokakashi-scan.yaml # run on changes to this workflow file
+      - registry-automation/** # run on changes to the registry automation files
+  schedule:
+    - cron: '0 0 * * *' # everyday at midnight
+
+jobs:
+  gokakashi-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch_depth: 1
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.22.x
+
+      - name: Download gokakashi
+        id: download_gokakashi
+        run: |
+          # Define URL and output path
+          URL="https://github.com/shinobistack/gokakashi/releases/download/v0.2.0/gokakashi-linux-amd64"
+          DEST="$RUNNER_TEMP/gokakashi"
+
+          # Download and make it executable
+          curl -L "$URL" -o "$DEST"
+          chmod +x "$DEST"
+          echo "Gokakashi binary downloaded to $DEST"
+
+          echo "gokakashi_path=$DEST" >> "$GITHUB_OUTPUT"
+
+      - name: Run Gokakashi Scan
+        run: |
+          cd registry-automation
+          go run main.go scan gokakashi \
+            --files "../registry/*/*/releases/*/connector-packaging.json" \
+            --server "${{ secrets.GOKAKASHI_SERVER_URL }}" \
+            --token "${{ secrets.GOKAKASHI_API_TOKEN }}" \
+            --policy ci-platform \
+            --cf-access-client-id "${{ secrets.GOKAKASHI_CF_ACCESS_CLIENT_ID }}" \
+            --cf-access-client-secret "${{ secrets.GOKAKASHI_CF_ACCESS_CLIENT_SECRET }}" \
+            --binary-path "$GOKAKASHI_PATH"
+        env:
+          GOKAKASHI_PATH: ${{ steps.download_gokakashi.outputs.gokakashi_path }}

--- a/.github/workflows/pr-scan.yaml
+++ b/.github/workflows/pr-scan.yaml
@@ -1,0 +1,54 @@
+name: Vulnerability Scan for Pull Requests
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - registry/**/connector-packing.json
+      - .github/workflows/pr-scan.yaml
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch_depth: 1
+
+      - name: Get all connector version package changes
+        id: connector-version-changed-files
+        uses: tj-actions/changed-files@v46.0.1
+        with:
+          json: true
+          escape_json: false
+          files: |
+            registry/**
+
+      - name: Print out all the changed filse
+        env:
+          ADDED_FILES: ${{ steps.connector-version-changed-files.outputs.added_files }}
+          MODIFIED_FILES: ${{ steps.connector-version-changed-files.outputs.modified_files }}
+          DELETED_FILES: ${{ steps.connector-version-changed-files.outputs.deleted_files }}
+        run: |
+          echo "{\"added_files\": $ADDED_FILES, \"modified_files\": $MODIFIED_FILES, \"deleted_files\": $DELETED_FILES}" > changed_files.json
+
+      - name: List changed files
+        id: list_files
+        run: |
+          cat changed_files.json
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Run Scan
+        env:
+          CHANGED_FILES_PATH: "changed_files.json"
+        run: |
+          mv changed_files.json registry-automation/changed_files.json
+          cd registry-automation
+          go run main.go scan trivy

--- a/registry-automation/cmd/ci.go
+++ b/registry-automation/cmd/ci.go
@@ -34,7 +34,7 @@ var ciCmd = &cobra.Command{
 var ciCmdArgs ConnectorRegistryArgs
 
 func init() {
-	rootCmd.AddCommand(ciCmd)
+	RootCmd.AddCommand(ciCmd)
 
 	// Path for the changed files in the PR
 	var changedFilesPathEnv = os.Getenv("CHANGED_FILES_PATH")
@@ -626,7 +626,7 @@ func uploadConnectorVersionPackage(ciCtx Context, connector Connector, version s
 		return connectorVersion, fmt.Errorf("invalid or undefined TGZ URL: %v", tgzUrl)
 	}
 
-	connectorVersionMetadata, connectorMetadataTgzPath, err := pkg.GetConnectorVersionMetadata(tgzUrl,
+	connectorVersionMetadata, connectorMetadataTgzPath,  _, err := pkg.GetConnectorVersionMetadata(tgzUrl,
 		connector.Namespace, connector.Name, version)
 	if err != nil {
 		return connectorVersion, err

--- a/registry-automation/cmd/download_artifacts.go
+++ b/registry-automation/cmd/download_artifacts.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/hasura/ndc-hub/registry-automation/pkg/ndchub"
+	"github.com/spf13/cobra"
+)
+
+var downloadArtifactsCmd = &cobra.Command{
+	Use:   "download-artifacts",
+	Short: "Downloads the artifacts from the connector registry",
+	Run:   runDownloadArtifactsCmd,
+}
+
+var downloadArtifactsCmdArgs ConnectorRegistryArgs
+
+func init() {
+	RootCmd.AddCommand(downloadArtifactsCmd)
+	var changedFilesPathEnv = os.Getenv("CHANGED_FILES_PATH") // this file contains the list of changed files
+	downloadArtifactsCmd.PersistentFlags().StringVar(&downloadArtifactsCmdArgs.ChangedFilesPath, "changed-files-path", changedFilesPathEnv, "path to a line-separated list of changed files in the PR")
+	if changedFilesPathEnv == "" {
+		downloadArtifactsCmd.MarkPersistentFlagRequired("changed-files-path")
+	}
+}
+
+type ArtifactDownloadOptions struct {
+	ChangedFilesPath string
+	SingleFilePath   string
+}
+
+type ArtifactOption func(*ArtifactDownloadOptions)
+
+func WithChangedFilesPath(path string) ArtifactOption {
+	return func(o *ArtifactDownloadOptions) {
+		o.ChangedFilesPath = path
+	}
+}
+
+func WithSingleFile(path string) ArtifactOption {
+	return func(o *ArtifactDownloadOptions) {
+		o.SingleFilePath = path
+	}
+}
+
+func DownloadArtifacts(opts ...ArtifactOption) ([]*ndchub.ConnectorArtifacts, error) {
+	options := &ArtifactDownloadOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.ChangedFilesPath == "" && options.SingleFilePath == "" {
+		return nil, fmt.Errorf("at least one of ChangedFilesPath or SingleFilePath must be provided")
+	}
+
+	if options.ChangedFilesPath != "" {
+		connectorPackagingFiles, err := getConnectorPackagingFilesFromChangedFiles(options.ChangedFilesPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get connector packaging files from changed files: %w", err)
+		}
+		return downloadArtifacts(connectorPackagingFiles)
+	} else {
+		// If a single file path is provided, we can directly download the artifacts for that file
+		artifacts, err := downloadArtifactsUtil(options.SingleFilePath)
+		artifactsArr := []*ndchub.ConnectorArtifacts{artifacts}
+		return artifactsArr, err
+	}
+}
+
+func getChangedFiles(filepath string) (*ChangedFiles, error) {
+	changedFilesContent, err := os.Open(filepath)
+	if err != nil {
+		// log.Fatalf("Failed to open the file: %v, err: %v", ciCmdArgs.ChangedFilesPath, err)
+		return nil, fmt.Errorf("failed to open the file: %v, err: %w", downloadArtifactsCmdArgs.ChangedFilesPath, err)
+	}
+	defer changedFilesContent.Close()
+
+	// Read the changed file's contents. This file contains all the changed files in the PR
+	changedFilesByteValue, err := io.ReadAll(changedFilesContent)
+	if err != nil {
+		// log.Fatalf("Failed to read the changed files JSON file: %v", err)
+		return nil, fmt.Errorf("failed to read the changed files JSON file: %w", err)
+	}
+
+	var changedFiles *ChangedFiles = &ChangedFiles{}
+	err = json.Unmarshal(changedFilesByteValue, changedFiles)
+	if err != nil {
+		// log.Fatalf("Failed to unmarshal the changed files content: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal the changed files content: %w", err)
+	}
+
+	return changedFiles, nil
+}
+
+// for now, since we're only adding support for newly added connectors, we will only check for the added files
+// in the added files, we only need files that end with connector-packaging.json
+func filterConnectorPackagingFiles(changedFiles *ChangedFiles) []string {
+	// Filter the changed files to only include the ones that are in the connector registry
+	var filteredChangedFiles []string = make([]string, 0)
+	for _, file := range changedFiles.Added {
+		if isConnectorPackagingFile(file) {
+			filteredChangedFiles = append(filteredChangedFiles, file)
+		}
+	}
+
+	log.Printf("Filtered connector packaging files: %v", filteredChangedFiles)
+	return filteredChangedFiles
+}
+
+func isConnectorPackagingFile(path string) bool {
+	return filepath.Base(path) == "connector-packaging.json"
+}
+
+func getConnectorPackaging(filePath string) (*ndchub.ConnectorPackaging, error) {
+	if !filepath.IsAbs(filePath) {
+		filePath = filepath.Join("../", filePath) // the filepaths returned by the changed files action are relative to the root of the repository. Therefore, we need to prepend "../" to the path to get the correct path
+	}
+	ndcHubConnectorPackaging, err := ndchub.GetConnectorPackaging(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the connector packaging for file %s: %w", filePath, err)
+	}
+	return ndcHubConnectorPackaging, nil
+}
+
+func getConnectorPackagingFilesFromChangedFiles(changedFilesPath string) ([]string, error) {
+	// Get the changed files from the PR
+	changedFiles, err := getChangedFiles(changedFilesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the connector packaging files (connector-packaging.json) from the changed files
+	connectorPackagingFiles := filterConnectorPackagingFiles(changedFiles)
+	return connectorPackagingFiles, nil
+}
+
+func downloadArtifacts(connectorPackagingFiles []string) ([]*ndchub.ConnectorArtifacts, error) {
+	artifactList := make([]*ndchub.ConnectorArtifacts, 0)
+	for _, file := range connectorPackagingFiles {
+		log.Printf("\n\n") // for more readable logs
+		artifacts, err := downloadArtifactsUtil(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download artifacts for file %s: %w", file, err)
+		}
+		artifactList = append(artifactList, artifacts)
+	}
+
+	return artifactList, nil
+}
+
+func downloadArtifactsUtil(connectorPackagingFilePath string) (*ndchub.ConnectorArtifacts, error) {
+	connectorPackaging, err := getConnectorPackaging(connectorPackagingFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the connector packaging: %w", err)
+	}
+
+	connectorMetadata, _, extractedTgzPath, err := ndchub.GetPackagingSpec(connectorPackaging.URI, 
+		connectorPackaging.Namespace,
+		connectorPackaging.Name, 
+		connectorPackaging.Version,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connector metadata for %s/%s:%s: %w",
+			connectorPackaging.Namespace, connectorPackaging.Name, connectorPackaging.Version, err)
+	}
+
+	artifacts, err := connectorMetadata.GetArtifacts(extractedTgzPath)	
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the artifacts for %s/%s:%s: %w",
+			connectorPackaging.Namespace, connectorPackaging.Name, connectorPackaging.Version, err)
+	}
+	
+	return artifacts, nil
+}
+
+func runDownloadArtifactsCmd(cmd *cobra.Command, args []string) {
+	artifacts, err := DownloadArtifacts(WithChangedFilesPath(downloadArtifactsCmdArgs.ChangedFilesPath))
+	if err != nil {
+		fmt.Printf("Failed to download artifacts: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print artifactList as JSON
+	artifactListJSON, err := json.MarshalIndent(artifacts, "", "  ")
+	if err != nil {
+		fmt.Printf("Failed to marshal artifact list to JSON: %v\n", err)
+		return
+	}
+	fmt.Println(string(artifactListJSON))
+}

--- a/registry-automation/cmd/e2e.go
+++ b/registry-automation/cmd/e2e.go
@@ -50,7 +50,7 @@ func init() {
 
 	e2eCmd.AddCommand(e2eChangedCmd, e2eLatest, e2eAll)
 
-	rootCmd.AddCommand(e2eCmd)
+	RootCmd.AddCommand(e2eCmd)
 }
 
 func e2eChanged(cmd *cobra.Command, args []string) {

--- a/registry-automation/cmd/root.go
+++ b/registry-automation/cmd/root.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
 	Use:   "registry-automation",
 	Short: "Commands associated with automation for the hub registry",
 }
@@ -15,7 +15,7 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
+	err := RootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/registry-automation/cmd/scan/gokakashi.go
+++ b/registry-automation/cmd/scan/gokakashi.go
@@ -1,0 +1,163 @@
+package scan
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/hasura/ndc-hub/registry-automation/cmd"
+	"github.com/hasura/ndc-hub/registry-automation/pkg/ndchub"
+	"github.com/hasura/ndc-hub/registry-automation/pkg/vulnerabilityscan"
+	"github.com/spf13/cobra"
+)
+
+var gokakashiCmd = &cobra.Command{
+	Use:   "gokakashi",
+	Short: "Scan the connector images using Gokakashi",
+	Long:  `Scan the connector images for vulnerabilities and compliance issues using Gokakashi.`,
+	Run:   runGokakashiCmd,
+}
+
+var gokakashiCmdArgs = struct {
+	files                string
+	server               string
+	token                string
+	policy               string
+	cfAccessClientId     string
+	cfAccessClientSecret string
+	binaryPath           string
+}{}
+
+func init() {
+	// Add the gokakashi command to the scan command
+	scanCmd.AddCommand(gokakashiCmd)
+
+	var files = os.Getenv("GOKAKASHI_FILES")                                     // this is the glob pattern to match files for scanning
+	var serverEnv = os.Getenv("GOKAKASHI_SERVER")                                // this is the Gokakashi server URL
+	var tokenEnv = os.Getenv("GOKAKASHI_TOKEN")                                  // this is the Gokakashi server token
+	var policyEnv = os.Getenv("GOKAKASHI_POLICY")                                // this is the Gokakashi policy
+	var cfAccessClientIdEnv = os.Getenv("GOKAKASHI_CF_ACCESS_CLIENT_ID")         // this is the Cloudflare Access Client ID
+	var cfAccessClientSecretEnv = os.Getenv("GOKAKASHI_CF_ACCESS_CLIENT_SECRET") // this is the Cloudflare Access Client Secret
+	var binaryPath = os.Getenv("GOKAKASHI_BINARY_PATH")                          // this is the path to the Gokakashi binary
+
+	gokakashiCmd.PersistentFlags().StringVar(&gokakashiCmdArgs.files, "files", files, "Glob pattern to match files for scanning (env: GOKAKASHI_FILES)")
+	gokakashiCmd.PersistentFlags().StringVar(&gokakashiCmdArgs.server, "server", serverEnv, "Server URL for Gokakashi (env: GOKAKASHI_SERVER)")
+	gokakashiCmd.PersistentFlags().StringVar(&gokakashiCmdArgs.token, "token", tokenEnv, "Token for Gokakashi server authentication (env: GOKAKASHI_TOKEN)")
+	gokakashiCmd.PersistentFlags().StringVar(&gokakashiCmdArgs.policy, "policy", policyEnv, "Policy for Gokakashi (env: GOKAKASHI_POLICY)")
+	gokakashiCmd.PersistentFlags().StringVar(&gokakashiCmdArgs.cfAccessClientId, "cf-access-client-id", cfAccessClientIdEnv, "Cloudflare Access Client ID for Gokakashi (env: GOKAKASHI_CF_ACCESS_CLIENT_ID)")
+	gokakashiCmd.PersistentFlags().StringVar(&gokakashiCmdArgs.cfAccessClientSecret, "cf-access-client-secret", cfAccessClientSecretEnv, "Cloudflare Access Client Secret for Gokakashi (env: GOKAKASHI_CF_ACCESS_CLIENT_SECRET)")
+	gokakashiCmd.PersistentFlags().StringVar(&gokakashiCmdArgs.binaryPath, "binary-path", binaryPath, "(Optional) Path to the Gokakashi binary. Defaults to 'gokakashi' in the system PATH. (env: GOKAKASHI_BINARY_PATH)")
+
+	if files == "" {
+		gokakashiCmd.MarkPersistentFlagRequired("files")
+	}
+	if serverEnv == "" {
+		gokakashiCmd.MarkPersistentFlagRequired("server")
+	}
+	if tokenEnv == "" {
+		gokakashiCmd.MarkPersistentFlagRequired("token")
+	}
+	if policyEnv == "" {
+		gokakashiCmd.MarkPersistentFlagRequired("policy")
+	}
+	if cfAccessClientIdEnv == "" {
+		gokakashiCmd.MarkPersistentFlagRequired("cf-access-client-id")
+	}
+	if cfAccessClientSecretEnv == "" {
+		gokakashiCmd.MarkPersistentFlagRequired("cf-access-client-secret")
+	}
+}
+
+func runGokakashiCmd(cmd *cobra.Command, args []string) {
+	files, err := getFiles(gokakashiCmdArgs.files)
+	if err != nil {
+		fmt.Printf("Error getting files: %v\n", err)
+		os.Exit(1)
+	}
+	if len(files) == 0 {
+		fmt.Println("No files found matching the glob pattern. Please check the GOKAKASHI_FILES environment variable or --files flag.")
+		os.Exit(1)
+	}
+
+	errors := []error{}
+	shouldExitWithNonZero := false
+
+	for _, file := range files {
+		log.Printf("\n\n")
+		artifacts, err := downloadArtifactsForGokakashi(file)
+		if err != nil {
+			err = fmt.Errorf("failed to download artifacts for file %s: %w. Skipping scan", file, err)
+			log.Printf("%s", err)
+			errors = append(errors, err)
+			shouldExitWithNonZero = true
+			continue
+		}
+		if len(artifacts) == 0 {
+			// something weird happened, no artifacts downloaded
+			err = fmt.Errorf("no artifacts downloaded for file %s. Skipping scan", file)
+			log.Printf("%s", err)
+			errors = append(errors, err)
+			shouldExitWithNonZero = true
+			continue
+		}
+
+		scanErrors, err := vulnerabilityscan.ScanDockerImageWithGokakashi(
+			vulnerabilityscan.WithDockerImagesForScan(artifacts[0].DockerImages), // since we're scanning one file at a time, we can take the first artifact
+			vulnerabilityscan.WithServer(gokakashiCmdArgs.server),
+			vulnerabilityscan.WithToken(gokakashiCmdArgs.token),
+			vulnerabilityscan.WithPolicy(gokakashiCmdArgs.policy),
+			vulnerabilityscan.WithCfAccessClientId(gokakashiCmdArgs.cfAccessClientId),
+			vulnerabilityscan.WithCfAccessClientSecret(gokakashiCmdArgs.cfAccessClientSecret),
+			vulnerabilityscan.WithCustomBin(gokakashiCmdArgs.binaryPath),
+		)
+		if err != nil {
+			fmt.Printf("error while running Gokakashi scan: %v\n", err)
+			os.Exit(1)
+		}
+		if len(scanErrors) > 0 {
+			shouldExitWithNonZero = true
+			for _, err := range scanErrors {
+				errors = append(errors, err)
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		fmt.Printf("\nErrors encountered during Gokakashi scan:\n\n")
+		for _, err := range errors {
+			fmt.Printf("%s\n\n", err.Error())
+		}
+	}
+
+	if shouldExitWithNonZero {
+		os.Exit(1)
+	}
+}
+
+func downloadArtifactsForGokakashi(file string) ([]*ndchub.ConnectorArtifacts, error) {
+	artifacts, err := cmd.DownloadArtifacts(cmd.WithSingleFile(file))
+	if err != nil {
+		return nil, fmt.Errorf("failed to download artifacts: %w", err)
+	}
+	return artifacts, nil
+}
+
+func getFiles(path string) ([]string, error) {
+	matches, err := filepath.Glob(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve glob pattern: %w", err)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no files matched pattern: %s", path)
+	}
+	absFiles := make([]string, 0, len(matches))
+	for _, match := range matches {
+		absPath, err := filepath.Abs(match)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get absolute path for %s: %w", match, err)
+		}
+		absFiles = append(absFiles, absPath)
+	}
+	return absFiles, nil
+}

--- a/registry-automation/cmd/scan/scan.go
+++ b/registry-automation/cmd/scan/scan.go
@@ -1,0 +1,20 @@
+package scan
+
+import (
+	"github.com/hasura/ndc-hub/registry-automation/cmd"
+	"github.com/spf13/cobra"
+)
+
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Scan the connector images",
+	Long: `Scan the connector images for vulnerabilities and compliance issues.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(scanCmd)
+}

--- a/registry-automation/cmd/scan/trivy.go
+++ b/registry-automation/cmd/scan/trivy.go
@@ -1,0 +1,67 @@
+package scan
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hasura/ndc-hub/registry-automation/cmd"
+	"github.com/hasura/ndc-hub/registry-automation/pkg/vulnerabilityscan"
+	"github.com/hasura/ndc-hub/registry-automation/pkg/ndchub"
+	"github.com/spf13/cobra"
+)
+
+var trivyCmd = &cobra.Command{
+	Use:   "trivy",
+	Short: "Scan the connector images using Trivy",
+	Long:  `Scan the connector images for vulnerabilities and compliance issues using Trivy.`,
+	Run: runTrivyCmd,
+}
+
+var trivyCmdArgs = struct {
+	ChangedFilesPath string
+}{}
+
+func init() {
+	// Add the trivy command to the scan command
+	scanCmd.AddCommand(trivyCmd)
+
+	var changedFilesPathEnv = os.Getenv("CHANGED_FILES_PATH") // this file contains the list of changed files
+	trivyCmd.PersistentFlags().StringVar(&trivyCmdArgs.ChangedFilesPath, "changed-files-path", changedFilesPathEnv, "path to a line-separated list of changed files in the PR")
+	if changedFilesPathEnv == "" {
+		trivyCmd.MarkPersistentFlagRequired("changed-files-path")
+	}
+}
+
+func downloadArtifacts(changedFilesPath string) ([]*ndchub.ConnectorArtifacts, error)  {
+	artifacts, err := cmd.DownloadArtifacts(cmd.WithChangedFilesPath(changedFilesPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to download artifacts: %w", err)
+	}
+	return artifacts, nil
+}
+
+func scanConnectorImages(artifacts []*ndchub.ConnectorArtifacts) {
+	for _, artifact := range artifacts {
+		vulnerabilityscan.ScanArtifacts(artifact)
+	}
+}
+
+func runTrivyCmd(cmd *cobra.Command, args []string) {
+	changedFilesPath := trivyCmdArgs.ChangedFilesPath
+	if changedFilesPath == "" {
+		fmt.Println("No changed files path provided. Please set the CHANGED_FILES_PATH environment variable or use the --changed-files-path flag.")
+		os.Exit(1)
+	}
+
+	// Download artifacts based on changed files
+	artifacts, err := downloadArtifacts(changedFilesPath)
+	if err != nil {
+		fmt.Printf("Error downloading artifacts: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Scan each connector image for vulnerabilities
+	scanConnectorImages(artifacts)
+
+	fmt.Println("All connector images scanned successfully.")
+}

--- a/registry-automation/cmd/utils.go
+++ b/registry-automation/cmd/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func generateGCPObjectName(namespace, connectorName, version string) string {
@@ -31,8 +32,14 @@ func readJSONFile[T any](location string) (T, error) {
 // Note: The location is relative to the root of the repository
 func readFile(location string) ([]byte, error) {
 	// Read the file
+	var fileBytes []byte
+	var err error
 
-	fileBytes, err := os.ReadFile("../" + location)
+	if filepath.IsAbs(location) {
+		fileBytes, err = os.ReadFile(location)
+	} else {
+		fileBytes, err = os.ReadFile("../" + location) // previous behavior; written for backwards compatibility
+	}
 	if err != nil {
 		return fileBytes, fmt.Errorf("error reading file at location: %s %v", location, err)
 	}

--- a/registry-automation/cmd/validate.go
+++ b/registry-automation/cmd/validate.go
@@ -18,7 +18,7 @@ var validateCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(validateCmd)
+	RootCmd.AddCommand(validateCmd)
 }
 
 func executeValidateCmd(cmd *cobra.Command, args []string) {
@@ -120,7 +120,7 @@ func executeValidateCmd(cmd *cobra.Command, args []string) {
 
 	fmt.Println("Validating Packaging spec contents")
 	for _, cp := range connectorPkgs {
-		packagingSpec, err := ndchub.GetPackagingSpec(cp.connectorPackage.URI, cp.connectorPackage.Namespace, cp.connectorPackage.Name, cp.connectorPackage.Version)
+		packagingSpec, _, _, err := ndchub.GetPackagingSpec(cp.connectorPackage.URI, cp.connectorPackage.Namespace, cp.connectorPackage.Name, cp.connectorPackage.Version)
 		if err != nil {
 			fmt.Println("error getting packaging spec for", cp.connectorPackage.URI, err)
 			hasError = true

--- a/registry-automation/go.mod
+++ b/registry-automation/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cloudinary/cloudinary-go/v2 v2.8.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -18,7 +19,6 @@ require (
 	github.com/matryer/is v1.4.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
@@ -60,5 +60,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240711142825-46eb208f015d // indirect
 	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0
 )

--- a/registry-automation/go.sum
+++ b/registry-automation/go.sum
@@ -190,8 +190,6 @@ google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6h
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/registry-automation/main.go
+++ b/registry-automation/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/hasura/ndc-hub/registry-automation/cmd"
+import (
+	"github.com/hasura/ndc-hub/registry-automation/cmd"
+	_ "github.com/hasura/ndc-hub/registry-automation/cmd/scan" // Import scan package to register its commands=
+)
 
 func main() {
 	cmd.Execute()

--- a/registry-automation/pkg/ndchub/packaging_spec.go
+++ b/registry-automation/pkg/ndchub/packaging_spec.go
@@ -401,12 +401,12 @@ func (def *ConnectorMetadataDefinition) GetArtifacts(artifactsPath string) (*Con
 	}
 
 	// download CLI plugins
-	DownloadPluginBinaries(artifactsDirPath, WithConnectorMetadata(def))
+	err := DownloadPluginBinaries(artifactsDirPath, WithConnectorMetadata(def))
 
 	return &ConnectorArtifacts{
 		DockerImages:  dockerImages,
 		ArtifactsDirPath: artifactsDirPath,
-	}, nil
+	}, err
 }
 
 func getTempArtifactsPath(namespace, connectorName, version string) (string, error) {

--- a/registry-automation/pkg/ndchub/packaging_spec.go
+++ b/registry-automation/pkg/ndchub/packaging_spec.go
@@ -2,6 +2,8 @@ package ndchub
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/hasura/ndc-hub/registry-automation/pkg"
 	"gopkg.in/yaml.v3"
@@ -20,6 +22,11 @@ type ConnectorMetadataDefinition struct {
 
 	// https://github.com/hasura/ndc-hub/blob/main/rfcs/0007-packaging-documentation-page.md
 	DocumentationPage *string `json:"documentationPage,omitempty" yaml:"documentationPage,omitempty"`
+
+	// metadata for the connector, not a part of the packaging spec
+	Namespace string `json:"-" yaml:"-"`
+	Name 	string `json:"-" yaml:"-"`
+	VersionStr string `json:"-" yaml:"-"`
 }
 
 type PackagingType string
@@ -59,6 +66,14 @@ type PackagingDefinition struct {
 	Type        PackagingType `json:"type" yaml:"type"`
 	DockerImage *string       `json:"dockerImage,omitempty" yaml:"dockerImage,omitempty"`
 }
+
+func (p PackagingDefinition) GetDockerImage() string {
+	if p.Type == PrebuiltDockerImage {
+		return *p.DockerImage
+	}
+	return ""
+}
+
 type EnvironmentVariableDefinition struct {
 	Name         string  `json:"name" yaml:"name"`
 	Description  string  `json:"description" yaml:"description"`
@@ -75,6 +90,35 @@ type Commands struct {
 	UpgradeConfiguration       *Command `json:"upgradeConfiguration,omitempty" yaml:"upgradeConfiguration,omitempty"`
 }
 
+func (c *Commands) GetDockerImages() []string {
+	dockerImageSet := make(map[string]bool)
+	if c.Update != nil {
+		if img := c.Update.GetDockerImage(); img != "" {
+			dockerImageSet[img] = true
+		}
+	}
+	if c.Watch != nil {
+		if img := c.Watch.GetDockerImage(); img != "" {
+			dockerImageSet[img] = true
+		}
+	}
+	if c.PrintSchemaAndCapabilities != nil {
+		if img := c.PrintSchemaAndCapabilities.GetDockerImage(); img != "" {
+			dockerImageSet[img] = true
+		}
+	}
+	if c.UpgradeConfiguration != nil {
+		if img := c.UpgradeConfiguration.GetDockerImage(); img != "" {
+			dockerImageSet[img] = true
+		}
+	}
+	dockerImages := make([]string, 0, len(dockerImageSet))
+	for img := range dockerImageSet {
+		dockerImages = append(dockerImages, img)
+	}
+	return dockerImages
+}
+
 type CliPluginType string
 
 const (
@@ -86,6 +130,13 @@ const (
 type CliPluginDefinition struct {
 	Binary *BinaryCliPluginDefinition
 	Docker *DockerCliPluginDefinition
+}
+
+func (c *CliPluginDefinition) GetDockerImage() string {
+	if c.Docker != nil {
+		return c.Docker.GetDockerImage()
+	}
+	return "";
 }
 
 type BinaryCliPluginDefinition struct {
@@ -126,6 +177,10 @@ type DockerCliPluginDefinition struct {
 	DockerImage string        `json:"dockerImage" yaml:"dockerImage"`
 }
 
+func (d *DockerCliPluginDefinition) GetDockerImage() string {
+	return d.DockerImage
+}
+
 type CommandType string
 
 const (
@@ -139,6 +194,13 @@ type DockerizedCommand struct {
 	CommandArgs []string    `json:"commandArgs" yaml:"commandArgs"`
 }
 
+func (d *DockerizedCommand) GetDockerImage() string {
+	if d.Type == DockerizedCommandType {
+		return d.DockerImage
+	}
+	return ""
+}
+
 type ShellScriptCommand struct {
 	Type       CommandType `json:"type" yaml:"type"`
 	Bash       string      `json:"bash" yaml:"bash"`
@@ -149,6 +211,13 @@ type Command struct {
 	String             *string
 	DockerizedCommand  *DockerizedCommand
 	ShellScriptCommand *ShellScriptCommand
+}
+
+func (c *Command) GetDockerImage() string {
+	if c.DockerizedCommand != nil {
+		return c.DockerizedCommand.GetDockerImage()
+	}
+	return ""
 }
 
 func (x *Command) UnmarshalYAML(n *yaml.Node) error {
@@ -308,19 +377,103 @@ func (def *ConnectorMetadataDefinition) Validate() error {
 	return nil
 }
 
-func GetPackagingSpec(uri, namespace, name, version string) (*ConnectorMetadataDefinition, error) {
-	def, _, err := pkg.GetConnectorVersionMetadata(uri, namespace, name, version)
+
+
+// GetArtifacts will return the artifacts for the connector
+// It will have a list of all Docker images that the connector uses (if any). There can be multiple because there might be a connector image and a plugin image.
+//
+// arg artifactsPath is the path where the artifacts will be downloaded. If it is not provided, a random path will be generated.
+func (def *ConnectorMetadataDefinition) GetArtifacts(artifactsPath string) (*ConnectorArtifacts, error) {
+	// Get the docker images
+	dockerImages := def.GetDockerImages()
+
+	// Get the plugin dir path
+	artifactsDirPath := ""
+
+	if artifactsPath != "" {
+		artifactsDirPath = artifactsPath
+	} else {
+		artifactPath, err := getTempArtifactsPath(def.Namespace, def.Name, string(*def.Version))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get temp artifacts path: %v", err)
+		}
+		artifactsDirPath = artifactPath
+	}
+
+	// download CLI plugins
+	DownloadPluginBinaries(artifactsDirPath, WithConnectorMetadata(def))
+
+	return &ConnectorArtifacts{
+		DockerImages:  dockerImages,
+		ArtifactsDirPath: artifactsDirPath,
+	}, nil
+}
+
+func getTempArtifactsPath(namespace, connectorName, version string) (string, error) {
+	// Get the present working directory
+	pwd := os.Getenv("PWD")
+	if pwd == "" {
+		return "", fmt.Errorf("failed to get the present working directory")
+	}
+	// Create a temp path for the artifacts
+	tempPath := filepath.Join(pwd, "artifacts", namespace, connectorName, version)
+	if _, err := os.Stat(tempPath); os.IsNotExist(err) {
+		err := os.MkdirAll(tempPath, 0755)
+		if err != nil {
+			return "", fmt.Errorf("failed to create temp path for artifacts: %v",	 err)
+		}
+	}
+	return tempPath, nil
+
+}
+
+// GetDockerImages will return the docker images for the connector (if any)
+// There can be multiple because there might be a connector image and a plugin image.
+func (def *ConnectorMetadataDefinition) GetDockerImages() []string {
+	// fmt.Printf("GetDockerImages: %v\n", def)
+	dockerImages := make(map[string]bool) // map to avoid duplicates
+	if def.PackagingDefinition.GetDockerImage() != "" {
+		dockerImages[def.PackagingDefinition.GetDockerImage()] = true
+	}
+
+	if def.CliPlugin !=  nil && def.CliPlugin.GetDockerImage() != "" {
+		dockerImages[def.CliPlugin.GetDockerImage()] = true
+	}
+
+	for _, img := range def.Commands.GetDockerImages() {
+		dockerImages[img] = true
+	}
+
+	dockerImgArr := make([]string, 0, len(dockerImages))
+	for k := range dockerImages {
+    	dockerImgArr = append(dockerImgArr, k)
+	}
+	return dockerImgArr
+}
+
+func GetPackagingSpec(uri, namespace, name, version string) (connectorMetadataDefinition *ConnectorMetadataDefinition, tgzPath string, extractedTgzPath string, err error) {
+	def, tgzPath, extractedTgzPath, err := pkg.GetConnectorVersionMetadata(uri, namespace, name, version)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	defBytes, err := yaml.Marshal(def)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	var spec ConnectorMetadataDefinition
 	err = yaml.Unmarshal(defBytes, &spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal connector-metadata.yaml: %v", err)
+		return nil, "", "", fmt.Errorf("failed to unmarshal connector-metadata.yaml: %v", err)
 	}
-	return &spec, nil
+
+	spec.Namespace = namespace
+	spec.Name = name
+	spec.VersionStr = version
+
+	return &spec, tgzPath, extractedTgzPath, nil
+}
+
+type ConnectorArtifacts struct {
+	DockerImages []string
+	ArtifactsDirPath string
 }

--- a/registry-automation/pkg/ndchub/plugins_spec.go
+++ b/registry-automation/pkg/ndchub/plugins_spec.go
@@ -1,0 +1,140 @@
+package ndchub
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"path/filepath"
+
+	"github.com/hasura/ndc-hub/registry-automation/pkg"
+	"gopkg.in/yaml.v3"
+)
+
+type PluginManifest struct {
+	Name             string     `json:"name" yaml:"name"`
+	Version          string     `json:"version" yaml:"version"`
+	ShortDescription string     `json:"shortDescription" yaml:"shortDescription"`
+	Homepage         string     `json:"homepage" yaml:"homepage"`
+	Hidden           bool       `json:"hidden" yaml:"hidden"`
+	Platforms        []Platform `json:"platforms" yaml:"platforms"`
+}
+
+type Platform struct {
+	Selector string     `json:"selector" yaml:"selector"`
+	URI      string     `json:"uri" yaml:"uri"`
+	SHA256   string     `json:"sha256" yaml:"sha256"`
+	Bin      string     `json:"bin" yaml:"bin"`
+	Files    []FilePair `json:"files" yaml:"files"`
+}
+
+type FilePair struct {
+	From string `json:"from" yaml:"from"`
+	To   string `json:"to" yaml:"to"`
+}
+
+type ManifestDownloadOptions struct {
+    Name           string
+    Version             string
+    ConnectorMetadata   *ConnectorMetadataDefinition
+}
+
+type ManifestOption func(*ManifestDownloadOptions)
+
+func WithNameAndVersion(name, version string) ManifestOption {
+    return func(opt *ManifestDownloadOptions) {
+        opt.Name = name
+        opt.Version = version
+    }
+}
+
+func WithConnectorMetadata(md *ConnectorMetadataDefinition) ManifestOption {
+    return func(opt *ManifestDownloadOptions) {
+        opt.ConnectorMetadata = md
+    }
+}
+
+func DownloadPluginBinaries(artifactsDirPath string, opts ...ManifestOption) {
+	manifest, err := DownloadPluginsManifest(opts...)
+	if err != nil {
+		log.Fatalf("Failed to download plugins manifest: %v", err)
+	}
+	if manifest == nil {
+		return
+	}
+
+	for _, platform := range manifest.Platforms {
+		fileName := fmt.Sprintf("%s-%s", platform.Selector, platform.Bin)
+		filePath := filepath.Join(artifactsDirPath, fileName)
+
+		if err := pkg.DownloadFile(platform.URI, filePath, map[string]string{"sha256": platform.SHA256}); err != nil {
+			log.Fatalf("Failed to download plugin binary for %s: %v", platform.Selector, err)
+		}
+	}
+}
+
+func DownloadPluginsManifest(opts ...ManifestOption) (*PluginManifest, error) {
+    var options ManifestDownloadOptions
+
+    // Apply options
+    for _, opt := range opts {
+        opt(&options)
+    }
+
+    switch {
+    case options.ConnectorMetadata != nil:
+        return downloadPluginsManifestWithConnectorMetadata(options.ConnectorMetadata)
+
+    case options.Name != "" && options.Version != "":
+        return downloadPluginsManifestWithNameAndVersion(options.Name, options.Version)
+
+    default:
+        return nil, fmt.Errorf("insufficient parameters provided to DownloadPluginsManifest")
+    }
+}
+
+func downloadPluginsManifestWithConnectorMetadata(md *ConnectorMetadataDefinition) (*PluginManifest, error) {
+	if md == nil {
+		return nil, fmt.Errorf("error downloading plugins manifest: connector metadata cannot be nil")
+	}
+	if md.CliPlugin == nil {
+		log.Printf("No CLI Plugin found for %s/%s:%s. Skipping download", md.Namespace, md.Name, md.VersionStr)
+		return nil, nil
+	}
+	if md.CliPlugin.Docker != nil && md.CliPlugin.Docker.DockerImage != "" {
+		log.Printf("CLI Plugin for %s/%s:%s is a Docker Image, skipping binary download", md.Namespace, md.Name, md.VersionStr)
+		return nil, nil
+	}
+	return downloadPluginsManifestWithNameAndVersion(md.CliPlugin.Binary.External.Name, md.CliPlugin.Binary.External.Version)
+}
+
+func downloadPluginsManifestWithNameAndVersion(name, version string) (*PluginManifest, error) {
+	if name == "" {
+		return nil, fmt.Errorf("error downloading plugins manifest: name cannot be empty")
+	}
+	if version == "" {
+		return nil, fmt.Errorf("error downloading plugins manifest: version cannot be empty")
+	}
+
+	manifestURL := getManifestUrl(name, version)
+	log.Printf("Downloading manifest from %s", manifestURL)
+	resp, err := http.Get(manifestURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download manifest from %s: %v", manifestURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download manifest: %s", resp.Status)
+	}
+
+	var manifest PluginManifest
+	if err := yaml.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("failed to decode manifest: %v", err)
+	}
+
+	return &manifest, nil
+}
+
+func getManifestUrl(name, version string) string {
+	return fmt.Sprintf("https://raw.githubusercontent.com/hasura/cli-plugins-index/refs/heads/master/plugins/%s/%s/manifest.yaml", name, version)
+}

--- a/registry-automation/pkg/vulnerabilityscan/gokakashi.go
+++ b/registry-automation/pkg/vulnerabilityscan/gokakashi.go
@@ -21,7 +21,7 @@ func (g *gokakashi) notFoundError() error {
 	return fmt.Errorf("unable to find gokakashi at %s \n\nDownload link: %s", g.gokakashiBinaryPath, gokakashiDownloadlLink)
 }
 
-const gokakashiDownloadlLink = "https://github.com/shinobistack/gokakashi/releases/tag/v0.2.0"
+const gokakashiDownloadlLink = "https://github.com/shinobistack/gokakashi/releases/latest/"
 
 func UseCustomGokakashiBinaryPath(path string) *gokakashi {
 	return &gokakashi{

--- a/registry-automation/pkg/vulnerabilityscan/gokakashi.go
+++ b/registry-automation/pkg/vulnerabilityscan/gokakashi.go
@@ -1,0 +1,192 @@
+package vulnerabilityscan
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// use this struct if you want to use gokakashi binary from a different path
+type gokakashi struct {
+	gokakashiBinaryPath string
+}
+
+func (g *gokakashi) notFoundError() error {
+	if g.gokakashiBinaryPath == GokakashiBinaryPath {
+		return fmt.Errorf("unable to find gokakashi \n\nDownload link: %s", gokakashiDownloadlLink)
+	}
+	return fmt.Errorf("unable to find gokakashi at %s \n\nDownload link: %s", g.gokakashiBinaryPath, gokakashiDownloadlLink)
+}
+
+const gokakashiDownloadlLink = "https://github.com/shinobistack/gokakashi/releases/tag/v0.2.0"
+
+func UseCustomGokakashiBinaryPath(path string) *gokakashi {
+	return &gokakashi{
+		gokakashiBinaryPath: path,
+	}
+}
+
+func GetDefaultGokakashiBin() *gokakashi {
+	return &gokakashi{
+		gokakashiBinaryPath: GokakashiBinaryPath,
+	}
+}
+
+const GokakashiBinaryPath = "gokakashi"
+
+func isGokakashiInstalled(gokakashi *gokakashi) bool {
+	_, err := exec.LookPath(gokakashi.gokakashiBinaryPath)
+	return err == nil
+}
+
+type GokakashiScanOptions struct {
+	dockerImages         []string
+	server               string
+	token                string
+	policy               string
+	cfAccessClientId     string
+	cfAccessClientSecret string
+	gokakashi            *gokakashi
+}
+
+type GokakashiOption func(*GokakashiScanOptions)
+
+func WithDockerImagesForScan(dockerImages []string) GokakashiOption {
+	return func(opts *GokakashiScanOptions) {
+		opts.dockerImages = dockerImages
+	}
+}
+
+func WithServer(server string) GokakashiOption {
+	return func(opts *GokakashiScanOptions) {
+		opts.server = server
+	}
+}
+
+func WithToken(token string) GokakashiOption {
+	return func(opts *GokakashiScanOptions) {
+		opts.token = token
+	}
+}
+
+func WithPolicy(policy string) GokakashiOption {
+	return func(opts *GokakashiScanOptions) {
+		opts.policy = policy
+	}
+}
+
+func WithCfAccessClientId(clientId string) GokakashiOption {
+	return func(opts *GokakashiScanOptions) {
+		opts.cfAccessClientId = clientId
+	}
+}
+
+func WithCfAccessClientSecret(clientSecret string) GokakashiOption {
+	return func(opts *GokakashiScanOptions) {
+		opts.cfAccessClientSecret = clientSecret
+	}
+}
+
+// returns the default Gokakashi binary if no path is provided, otherwise uses the custom path
+func WithCustomBin(path string) GokakashiOption {
+	var gokakashi *gokakashi = nil
+	if path != "" {
+		gokakashi = UseCustomGokakashiBinaryPath(path)
+	}
+	return func(opts *GokakashiScanOptions) {
+		opts.gokakashi = gokakashi
+	}
+}
+
+// scans docker images using Gokakashi
+// the single error returned is for validation errors or other issues that prevent the scan from running
+// the map returned contains errors for each image that failed to scan, with the image name as the key and the error as the value
+func ScanDockerImageWithGokakashi(opts ...GokakashiOption) (map[string]error, error) {
+	options := &GokakashiScanOptions{}
+	gokakashi := GetDefaultGokakashiBin()
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	errorMap := make(map[string]error)
+
+	if len(options.dockerImages) == 0 {
+		log.Printf("No Docker images provided for Gokakashi scan. Skipping scan.\n")
+		return errorMap, nil
+	}
+
+	if options.server == "" {
+		return errorMap, fmt.Errorf("server URL is required for Gokakashi scan")
+	}
+
+	if options.token == "" {
+		return errorMap, fmt.Errorf("token is required for Gokakashi scan")
+	}
+
+	if options.policy == "" {
+		return errorMap, fmt.Errorf("policy is required for Gokakashi scan")
+	}
+
+	if options.cfAccessClientId == "" {
+		return errorMap, fmt.Errorf("cloudflare Access Client ID is required for Gokakashi scan")
+	}
+
+	if options.cfAccessClientSecret == "" {
+		return errorMap, fmt.Errorf("cloudflare Access Client Secret is required for Gokakashi scan")
+	}
+
+	if options.gokakashi != nil {
+		absPath, err := filepath.Abs(options.gokakashi.gokakashiBinaryPath)
+		if err != nil {
+			return errorMap, fmt.Errorf("error resolving path %s: %w", options.gokakashi.gokakashiBinaryPath, err)
+		}
+		gokakashi = options.gokakashi
+		gokakashi.gokakashiBinaryPath = absPath
+	}
+
+	if !isGokakashiInstalled(gokakashi) {
+		return errorMap, gokakashi.notFoundError()
+	}
+
+	for _, dockerImage := range options.dockerImages {
+		log.Printf("Starting scan for image %s with gokakashi\n", dockerImage)
+		if err := scanImageWithGokakashi(dockerImage, options); err != nil {
+			errorMap[dockerImage] = fmt.Errorf("error scanning %s with Gokakashi: %w", dockerImage, err)
+		}
+	}
+
+	return errorMap, nil
+}
+
+func scanImageWithGokakashi(dockerImage string, options *GokakashiScanOptions) error {
+	args := []string{
+		options.gokakashi.gokakashiBinaryPath,
+		"scan", "image",
+		"--image", dockerImage,
+		"--server", options.server,
+		"--token", options.token,
+		"--policy", options.policy,
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("CF_ACCESS_CLIENT_ID=%s", options.cfAccessClientId),
+		fmt.Sprintf("CF_ACCESS_CLIENT_SECRET=%s", options.cfAccessClientSecret),
+	)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	fmt.Println(out.String())
+
+	if err != nil {
+		return fmt.Errorf("gokakashi error: %w\nOutput: %s", err, out.String())
+	}
+
+	return nil
+}

--- a/registry-automation/pkg/vulnerabilityscan/trivy.go
+++ b/registry-automation/pkg/vulnerabilityscan/trivy.go
@@ -101,7 +101,7 @@ func scan(args ...string) error {
 		return fmt.Errorf("trivy execution failed: %w", err)
 	}
 
-	log.Printf("Trivy scan completed successfully. No vulerabilites found\n")
+	log.Printf("Trivy scan completed successfully. No vulnerabilities found\n")
 
 	return nil
 }

--- a/registry-automation/pkg/vulnerabilityscan/trivy.go
+++ b/registry-automation/pkg/vulnerabilityscan/trivy.go
@@ -1,0 +1,107 @@
+package vulnerabilityscan
+
+import (
+    "os/exec"
+    "fmt"
+    "os"
+    "syscall"
+	"bytes"
+	"log"
+
+	"github.com/hasura/ndc-hub/registry-automation/pkg/ndchub"
+)
+
+func ScanArtifacts(artifacts *ndchub.ConnectorArtifacts) {
+	for _, dockerImage := range artifacts.DockerImages {
+		err := ScanImageWithTrivyDocker(dockerImage)
+		if err != nil {
+			fmt.Printf("error when scanning image %s: %s", dockerImage, err)
+			os.Exit(1)
+		}
+	}
+
+	err := ScanDirWithTrivyDocker(artifacts.ArtifactsDirPath)
+	if err != nil {
+		fmt.Printf("error when scanning directory %s: %s", artifacts.ArtifactsDirPath, err)
+		os.Exit(1)
+	}
+}
+
+func ScanImageWithTrivyDocker(dockerImage string) error {
+	if dockerImage == "" {
+		log.Printf("Docker image is empty, skipping Trivy scan for image.\n")
+		return nil
+	}
+
+    log.Printf("Scanning docker image with trivy-docker: %s\n", dockerImage)
+    args := []string{
+			"run", "--rm",
+			"-v", "/var/run/docker.sock:/var/run/docker.sock", // Needed to access Docker daemon
+			"aquasec/trivy:latest",
+			"image", 
+			"--severity", "CRITICAL,HIGH",
+            "--exit-code", "1", 
+            "--no-progress", 
+            "--format", "table", 
+            dockerImage,
+		}
+
+	return scan(args...)
+}
+
+func ScanDirWithTrivyDocker(dirPath string) error {
+	if dirPath == "" {
+		log.Printf("Directory path is empty, skipping Trivy scan for directory.\n")
+		return nil
+	}
+
+	log.Printf("Scanning file directory with trivy-docker: %s\n", dirPath)
+
+	args := []string{
+		"run", "--rm",
+		"-v", fmt.Sprintf("%s:/target", dirPath), // Bind-mount the dir into /target inside the container
+		"aquasec/trivy:latest",
+		"fs", "/target",                          // Tell Trivy to scan the /target path
+		"--exit-code", "1",                       // Exit with code 1 if any vuln is found
+		"--no-progress",
+		"--format", "table",
+        "--scanners", "vuln,misconfig,secret,license",
+		"--severity", "CRITICAL,HIGH",
+	}
+
+	return scan(args...)
+}
+
+func scan(args ...string) error {
+    cmd := exec.Command("docker", args...)
+
+    // Uncomment the following lines to capture output in a buffer
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	// Uncomment the following lines to capture output in os.stdout and os.stderr (terminal)
+    // cmd.Stdout = os.Stdout
+	// cmd.Stderr = os.Stderr
+
+	log.Println("Running Trivy scan...")
+	err := cmd.Run()
+
+	if err != nil {
+		// we'll only print the output if there was an error
+		fmt.Println(out.String())
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			code := exitErr.Sys().(syscall.WaitStatus).ExitStatus()
+			fmt.Printf("Trivy exited with code: %d\n", code)
+			if code == 1 {
+				return fmt.Errorf("vulnerabilities found")
+			}
+			return fmt.Errorf("trivy failed with exit code %d", code)
+		}
+		return fmt.Errorf("trivy execution failed: %w", err)
+	}
+
+	log.Printf("Trivy scan completed successfully. No vulerabilites found\n")
+
+	return nil
+}


### PR DESCRIPTION
This PR adds vulnerability scanning for new connector releases

## How
Three new commands have been added:
1. `download-artifacts`: This command is responsible for downloading connector artifacts (CLI Plugins, targz file, Docker Images)
2. `scan trivy`: This command scans the downloaded connector artifacts using Trivy
3. `scan gokakashi`: This commands scans all connector docker images using Gokakashi

Trivy scan runs on new PRs
Gokakashi scan runs once a day periodically

## Review
This PR refactors and changes a few files. I've broken the changes down by commits. I'd recommend using commits to review this.

## Tests
Tests for the new commands (and functions) are not yet present. I'll be adding them in a follow up PR