### PR TITLE
Release Go connector v2.0.0

### DIFF
--- a/registry/hasura/go/metadata.json
+++ b/registry/hasura/go/metadata.json
@@ -5,7 +5,7 @@
     "title": "Go Connector",
     "logo": "logo.svg",
     "tags": [],
-    "latest_version": "v1.10.0"
+    "latest_version": "v2.0.0"
   },
   "author": {
     "support_email": "support@hasura.io",

--- a/registry/hasura/go/releases/v2.0.0/connector-packaging.json
+++ b/registry/hasura/go/releases/v2.0.0/connector-packaging.json
@@ -3,10 +3,10 @@
   "uri": "https://github.com/hasura/ndc-sdk-go/releases/download/v2.0.0/connector-definition.tgz",
   "checksum": {
     "type": "sha256",
-    "value": "7216ed69a4a39e3bfb852992fff7845c6c82ce4dc8cbfd7642893cf67a768f37"
+    "value": "81e055697d744b53d2d1b5a9b06079721d3f80604f65001a170625df00dd7160"
   },
   "source": {
-    "hash": "620bbfea39deba390399508dbfa7f5c5da94dc04"
+    "hash": "fe75c8104cdb9dbb11f8eec4de645e3004f5fd49"
   },
   "test": {
     "test_config_path": "../../tests/test-config.json"

--- a/registry/hasura/go/releases/v2.0.0/connector-packaging.json
+++ b/registry/hasura/go/releases/v2.0.0/connector-packaging.json
@@ -1,0 +1,14 @@
+{
+  "version": "v2.0.0",
+  "uri": "https://github.com/hasura/ndc-sdk-go/releases/download/v2.0.0/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "7216ed69a4a39e3bfb852992fff7845c6c82ce4dc8cbfd7642893cf67a768f37"
+  },
+  "source": {
+    "hash": "620bbfea39deba390399508dbfa7f5c5da94dc04"
+  },
+  "test": {
+    "test_config_path": "../../tests/test-config.json"
+  }
+}


### PR DESCRIPTION
[Changelog](https://github.com/hasura/ndc-sdk-go/releases/tag/v2.0.0)