### PR TITLE
Release GraphQL connector v0.3.0

### DIFF
--- a/registry/hasura/graphql/metadata.json
+++ b/registry/hasura/graphql/metadata.json
@@ -5,7 +5,7 @@
     "title": "GraphQL Native Data Connector",
     "logo": "logo.svg",
     "tags": [],
-    "latest_version": "v0.2.3"
+    "latest_version": "v0.3.0"
   },
   "author": {
     "support_email": "support@hasura.io",
@@ -16,33 +16,6 @@
   "is_hosted_by_hasura": false,
   "source_code": {
     "is_open_source": true,
-    "repository": "https://github.com/hasura/ndc-graphql/",
-    "version": [
-      {
-        "tag": "v0.2.0",
-        "hash": "6296807daffb437a2f4dd158cab4c58d51ecd37c",
-        "is_verified": true
-      },
-      {
-        "tag": "v0.1.3",
-        "hash": "4262e34d57255c622a47daa408eba8c25fb279f7",
-        "is_verified": true
-      },
-      {
-        "tag": "v0.1.2",
-        "hash": "1cfb5d3e52d914acf4e5e96edd54d7fc744ec304",
-        "is_verified": true
-      },
-      {
-        "tag": "v0.1.1",
-        "hash": "85b80185e28eb7f6721fc50ecd2552f96633e5db",
-        "is_verified": true
-      },
-      {
-        "tag": "v0.1.0",
-        "hash": "8fb41a151b3852fadcfadbe17695605f77aaa240",
-        "is_verified": true
-      }
-    ]
+    "repository": "https://github.com/hasura/ndc-graphql/"
   }
 }

--- a/registry/hasura/graphql/releases/v0.3.0/connector-packaging.json
+++ b/registry/hasura/graphql/releases/v0.3.0/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.3.0",
+  "uri": "https://github.com/hasura/ndc-graphql/releases/download/v0.3.0/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "e205acb31daee4d7e9c881a511ee0b25892cfa2eff2741183938e540ecc051fb"
+  },
+  "source": {
+    "hash": "f7f60a27e83f8d1e1038616b0662a645b6eda77d"
+  }
+}

--- a/registry/hasura/graphql/releases/v0.3.0/connector-packaging.json
+++ b/registry/hasura/graphql/releases/v0.3.0/connector-packaging.json
@@ -7,5 +7,8 @@
   },
   "source": {
     "hash": "f7f60a27e83f8d1e1038616b0662a645b6eda77d"
+  },
+  "test": {
+    "test_config_path": "../../tests/test-config.json"
   }
 }


### PR DESCRIPTION
[Changelog](https://github.com/hasura/ndc-graphql/releases/tag/v0.3.0)