### PR TITLE
PromptQL GA4: Release v0.1.1

### DIFF
--- a/registry/hasura/promptql-ga4/metadata.json
+++ b/registry/hasura/promptql-ga4/metadata.json
@@ -8,7 +8,7 @@
       "google-analytics",
       "ga4"
     ],
-    "latest_version": "v0.1.0"
+    "latest_version": "v0.1.1"
   },
   "author": {
     "support_email": "support@hasura.io",
@@ -24,6 +24,11 @@
       {
         "tag": "v0.1.0",
         "hash": "0a59dba5bb0fdd34565f3c43ae21cc40f63fecd3",
+        "is_verified": true
+      },
+      {
+        "tag": "v0.1.1",
+        "hash": "d7f8e6489003edd3ecff8325125eed5fd3666607",
         "is_verified": true
       }
     ]

--- a/registry/hasura/promptql-ga4/releases/v0.1.1/connector-packaging.json
+++ b/registry/hasura/promptql-ga4/releases/v0.1.1/connector-packaging.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.1.1",
+  "uri": "https://github.com/hasura/promptql-GA4/releases/download/v0.1.1/connector-definition.tgz",
+  "checksum": {
+    "type": "sha256",
+    "value": "4a549f3fb832759f3d4b78d8448a273783c8355ed1b6c61606808e8e1785d98f"
+  },
+  "source": {
+    "hash": "d7f8e6489003edd3ecff8325125eed5fd3666607"
+  }
+}


### PR DESCRIPTION
This pull request adds support for version `v0.1.1` of the `promptql-ga4` connector in the registry. The update includes metadata changes and the addition of the release packaging for the new version.

Version update and metadata changes:

* Updated the `latest_version` field in `metadata.json` to `v0.1.1` and added a new release entry with its corresponding tag, hash, and verification status. [[1]](diffhunk://#diff-6a190c613b55167c07a87e54553dd971027135f9253fbbd48b95b42dca965eadL11-R11) [[2]](diffhunk://#diff-6a190c613b55167c07a87e54553dd971027135f9253fbbd48b95b42dca965eadR28-R32)

Release packaging:

* Added a new `connector-packaging.json` file for version `v0.1.1`, specifying the version, download URI, checksum, and source hash.