### PR TITLE
MySQL v1.0.19

### DIFF
--- a/registry/hasura/mysql/metadata.json
+++ b/registry/hasura/mysql/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v1.0.18"
+    "latest_version": "v1.0.19"
   },
   "author": {
     "support_email": "support@hasura.io",

--- a/registry/hasura/mysql/releases/v1.0.19/connector-packaging.json
+++ b/registry/hasura/mysql/releases/v1.0.19/connector-packaging.json
@@ -1,0 +1,14 @@
+{
+  "version": "v1.0.19",
+  "uri": "https://github.com/hasura/ndc-jvm-mono/releases/download/mysql%2Fv1.0.19/mysql-connector-v1.0.19.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "abfaf09c97327fe5d6bd1e98ba4df2c6d6fd5577c5f60d8b00d3ee10f8b28af0"
+  },
+  "source": {
+    "hash": "631d37452f26c736ed073c04bdce37d55bbff814"
+  },
+  "test": {
+    "test_config_path": "../../tests/test-config.json"
+  }
+}


### PR DESCRIPTION
Bumps the MySQL connector to **v1.0.19**.

> Re-opened from #742 on an upstream branch — fork PRs fail CI because GitHub Actions strips repo/org secrets from `pull_request` runs originating in forks.

## Changes

Picks up [hasura/ndc-jvm-mono#97](https://github.com/hasura/ndc-jvm-mono/pull/97) — *fix(mysql): apply unique table alias on self-referential relationship subqueries*.

When a relationship's source and target are the same collection (e.g. `regions.parentRegionId → regions.id`), the correlated subquery was previously aliased with the same name as the outer table scan. MySQL resolved both sides of the join condition to the inner scope, producing a tautological self-comparison that silently returned no rows.

Equivalent fix to [#88](https://github.com/hasura/ndc-jvm-mono/pull/88) (Snowflake/Trino) applied to MySQL's `JSONGenerator.kt`.

## Release artifacts

- Tag: [`mysql/v1.0.19`](https://github.com/hasura/ndc-jvm-mono/releases/tag/mysql/v1.0.19)
- Image: `ghcr.io/hasura/ndc-jvm-mysql:v1.0.19` (linux/amd64, linux/arm64)
- CLI: `ghcr.io/hasura/ndc-jvm-cli:v1.0.19-mysql`
- Source commit: `631d37452f26c736ed073c04bdce37d55bbff814`
- Tarball sha256: `abfaf09c97327fe5d6bd1e98ba4df2c6d6fd5577c5f60d8b00d3ee10f8b28af0`

Original contributor: @qamar-hashmi.