### PR TITLE
MySQL v1.0.20

### DIFF
--- a/registry/hasura/mysql/metadata.json
+++ b/registry/hasura/mysql/metadata.json
@@ -7,7 +7,7 @@
     "tags": [
       "database"
     ],
-    "latest_version": "v1.0.19"
+    "latest_version": "v1.0.20"
   },
   "author": {
     "support_email": "support@hasura.io",

--- a/registry/hasura/mysql/releases/v1.0.20/connector-packaging.json
+++ b/registry/hasura/mysql/releases/v1.0.20/connector-packaging.json
@@ -1,0 +1,14 @@
+{
+  "version": "v1.0.20",
+  "uri": "https://github.com/hasura/ndc-jvm-mono/releases/download/mysql%2Fv1.0.20/mysql-connector-v1.0.20.tar.gz",
+  "checksum": {
+    "type": "sha256",
+    "value": "9fef26d2b053b31667b2678f4e199f014f55c50ebd4f46fcf9f72ced881e7ab2"
+  },
+  "source": {
+    "hash": "7ea80f966e7abfeaba56957291ff555649e21809"
+  },
+  "test": {
+    "test_config_path": "../../tests/test-config.json"
+  }
+}


### PR DESCRIPTION
Bumps the MySQL connector to v1.0.20.

## Changes

Picks up hasura/ndc-jvm-mono#100 — *fix(mysql): decouple SQL alias from connector-config lookup in WHERE predicates*.

Fixes the v1.0.19 regression where any nested relationship with a `where` filter threw `IllegalStateException: Collection <alias>_<collection> not found in connector configuration`.

#97 (v1.0.19) introduced a unique inner alias for self-referential subqueries to fix the self-join correlation bug, but threaded that alias through `expressionToCondition(e, request, overrideCollection)` which copies it into `request.collection` for both SQL table qualification (correct) and connector-config lookup in `getColumnType` (incorrect — must be the real collection name). #100 splits these concerns via a new `expressionToConditionWithSqlAlias` API that keeps `request.collection` real while passing the SQL alias separately.

Adds two `ndc-test` snapshots under `ndc-spec-tests/mysql/query/` exercising the regression end-to-end against Chinook:

- `select_self_join_with_where` (Employee.ReportsTo self-FK + WHERE)
- `select_nested_cross_table_with_where` (Customer → Invoice → Customer → Invoice with WHERE on the deepest aliased subquery — direct analogue of the original bug report)

## Release artifacts

- Tag: [`mysql/v1.0.20`](https://github.com/hasura/ndc-jvm-mono/releases/tag/mysql/v1.0.20)
- Image: `ghcr.io/hasura/ndc-jvm-mysql:v1.0.20` (linux/amd64, linux/arm64)
- CLI: `ghcr.io/hasura/ndc-jvm-cli:v1.0.20-mysql`
- Source commit: `7ea80f966e7abfeaba56957291ff555649e21809`
- Tarball sha256: `9fef26d2b053b31667b2678f4e199f014f55c50ebd4f46fcf9f72ced881e7ab2`

Note: the auto-generated `connector-packaging.json` published with the release uses `test_config_path: ../../tests/tests-config.json` (plural), which doesn't match the actual file `registry/hasura/mysql/tests/test-config.json` (singular) — the version in this PR has the corrected singular path, matching v1.0.19's `connector-packaging.json`.