### PR TITLE
feat: Add env-loader support for ddn-native-workspace

### DIFF
--- a/.github/workflows/build-ddn-workspace-env-loader.yaml
+++ b/.github/workflows/build-ddn-workspace-env-loader.yaml
@@ -1,0 +1,72 @@
+name: Build and Push DDN Workspace Env-Loader
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: 'Base image tag to wrap (e.g., 20260511-174531-dbcfb1c or 2.7.9)'
+        required: true
+        type: string
+      env_loader_tag:
+        description: 'Tag for the env-loader image (defaults to base_tag-env-loader)'
+        required: false
+        type: string
+
+jobs:
+  build-env-loader:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup gcloud
+        env:
+          GCLOUD_EE_AUTH: ${{ secrets.GCLOUD_EE_AUTH }}
+        run: |
+          echo "$GCLOUD_EE_AUTH" | base64 -d > "$HOME"/gcloud.json
+          gcloud auth activate-service-account --key-file=$HOME/gcloud.json
+          gcloud auth configure-docker -q
+
+      - name: Determine tags
+        id: tags
+        run: |
+          BASE_TAG="${{ inputs.base_tag }}"
+          ENV_LOADER_TAG="${{ inputs.env_loader_tag }}"
+
+          if [ -z "$ENV_LOADER_TAG" ]; then
+            ENV_LOADER_TAG="${BASE_TAG}-env-loader"
+          fi
+
+          echo "base_tag=${BASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "env_loader_tag=${ENV_LOADER_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build env-loader image
+        working-directory: ddn-workspace
+        run: |
+          docker build \
+            -f Dockerfile_EnvLoader \
+            --build-arg WORKSPACE_VERSION=${{ steps.tags.outputs.base_tag }} \
+            -t gcr.io/hasura-ee/ddn-native-workspace:${{ steps.tags.outputs.env_loader_tag }} \
+            .
+
+      - name: Push env-loader image
+        run: |
+          docker push gcr.io/hasura-ee/ddn-native-workspace:${{ steps.tags.outputs.env_loader_tag }}
+
+      - name: Create summary
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          # DDN Native Workspace Env-Loader Built
+
+          **Base image:** gcr.io/hasura-ee/ddn-native-workspace:${{ steps.tags.outputs.base_tag }}
+          **Env-loader image:** gcr.io/hasura-ee/ddn-native-workspace:${{ steps.tags.outputs.env_loader_tag }}
+
+          ## Usage with External Secrets
+
+          This image variant reads secrets from /secrets/*.json files and exports them as environment variables before starting the workspace.
+
+          Use with Helm charts that have external secrets support (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault).
+          EOF

--- a/ddn-workspace/Dockerfile_EnvLoader
+++ b/ddn-workspace/Dockerfile_EnvLoader
@@ -1,0 +1,14 @@
+ARG WORKSPACE_VERSION
+
+FROM us-docker.pkg.dev/hasura-ddn/ddn/lux-env-loader-entrypoint:20250508.rc1 AS utilsource
+
+FROM gcr.io/hasura-ee/ddn-native-workspace:${WORKSPACE_VERSION}
+
+# Copy env-loader utilities from utilsource
+COPY --from=utilsource /usr/local/bin/docker-entrypoint.sh /usr/local/bin/env-loader-entrypoint.sh
+COPY --from=utilsource /usr/local/bin/jq /usr/local/bin/jq
+COPY --from=utilsource /usr/local/bin/inotifywait /usr/local/bin/inotifywait
+
+# IMPORTANT: The entrypoint in ddn-native-workspace is at /home/hasura/.local/bin/entrypoint.sh
+# It's on PATH so we can just reference it as "entrypoint.sh"
+ENTRYPOINT ["/usr/local/bin/env-loader-entrypoint.sh", "entrypoint.sh"]

--- a/ddn-workspace/Dockerfile_EnvLoader
+++ b/ddn-workspace/Dockerfile_EnvLoader
@@ -4,11 +4,12 @@ FROM us-docker.pkg.dev/hasura-ddn/ddn/lux-env-loader-entrypoint:20250508.rc1 AS 
 
 FROM gcr.io/hasura-ee/ddn-native-workspace:${WORKSPACE_VERSION}
 
-# Copy env-loader utilities from utilsource
-COPY --from=utilsource /usr/local/bin/docker-entrypoint.sh /usr/local/bin/env-loader-entrypoint.sh
-COPY --from=utilsource /usr/local/bin/jq /usr/local/bin/jq
-COPY --from=utilsource /usr/local/bin/inotifywait /usr/local/bin/inotifywait
+# Install inotify-tools (provides inotifywait) - jq is already present at /usr/bin/jq
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends inotify-tools && rm -rf /var/lib/apt/lists/*
+USER hasura
 
-# IMPORTANT: The entrypoint in ddn-native-workspace is at /home/hasura/.local/bin/entrypoint.sh
-# It's on PATH so we can just reference it as "entrypoint.sh"
+# Copy the env-loader entrypoint script
+COPY --from=utilsource /usr/local/bin/docker-entrypoint.sh /usr/local/bin/env-loader-entrypoint.sh
+
 ENTRYPOINT ["/usr/local/bin/env-loader-entrypoint.sh", "entrypoint.sh"]

--- a/ddn-workspace/README.md
+++ b/ddn-workspace/README.md
@@ -156,3 +156,31 @@ docker exec -it <container-id> bash
 - Review connector integration guide
 - Check GitHub Actions logs for build issues
 - Contact DDN team for support
+
+## Image Variants
+
+### Standard Image
+`gcr.io/hasura-ee/ddn-native-workspace:<tag>`
+
+The standard image for DDN workspace with all native connector runtimes.
+
+### Env-Loader Variant
+`gcr.io/hasura-ee/ddn-native-workspace:<tag>-env-loader`
+
+This variant wraps the standard image with an env-loader entrypoint that:
+1. Reads JSON files from `/secrets/*.json`
+2. Exports each key-value pair as environment variables
+3. Executes the standard entrypoint
+
+Use this variant when deploying with external secrets managers (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault) via the secrets-management-proxy init container pattern.
+
+To build the env-loader variant:
+```bash
+# Using the GitHub Actions workflow
+# Go to Actions > Build and Push DDN Workspace Env-Loader > Run workflow
+# Enter the base tag (e.g., 2.7.9 or 20260511-174531-dbcfb1c)
+
+# Or build locally
+docker build -f Dockerfile_EnvLoader --build-arg WORKSPACE_VERSION=2.7.9 -t ddn-native-workspace:2.7.9-env-loader .
+```
+


### PR DESCRIPTION
## Summary

Adds env-loader image variant support for ddn-native-workspace, enabling external secrets (HashiCorp Vault) integration.

## Changes

### `ddn-workspace/Dockerfile_EnvLoader`
- Wraps the base ddn-native-workspace image with env-loader entrypoint
- Installs `inotify-tools` package (provides `inotifywait` which the env-loader needs)
- Uses `entrypoint.sh` which is on PATH at `/home/hasura/.local/bin/`

### `.github/workflows/build-ddn-workspace-env-loader.yaml`
- New workflow to build and push env-loader variant
- Publishes to `gcr.io/hasura-ee/ddn-native-workspace:<tag>-env-loader`
- Manual trigger (workflow_dispatch) with tag input

### `ddn-workspace/README.md`
- Documents the env-loader variant and build process

## Usage

After merging:
1. Build the base image first (creates `gcr.io/hasura-ee/ddn-native-workspace:v2.7.9`)
2. Run the new env-loader workflow with the same tag (creates `gcr.io/hasura-ee/ddn-native-workspace:v2.7.9-env-loader`)

## Related

- ddn-helm-charts PR #61 (external secrets support for ddn-workspace helm chart)
